### PR TITLE
chore: configure dependabot for automatic package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 99


### PR DESCRIPTION
Configuring as a weekly update check instead of daily. I prefer daily myself, but you'll be the ones looking at these robot PRs, not me.