### PR TITLE
refactor: character list page ft. css grid

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -101,6 +101,11 @@
             "styles": [
               "src/styles/global.scss"
             ],
+            "stylePreprocessorOptions": {
+              "includePaths": [
+                "src/styles"
+              ]
+            },
             "scripts": []
           }
         },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -36,8 +36,6 @@ const baseUrlProvider = {
   declarations: [
     AppComponent,
     ArtifactComponent,
-    ArtifactComponent,
-    ArtifactComponent,
     ArtifactListComponent,
     CharacterCardComponent,
     CharacterComponent,
@@ -45,8 +43,6 @@ const baseUrlProvider = {
     DropdownContentCardComponent,
     FooterComponent,
     HomeComponent,
-    LinkHandlerDirective,
-    LinkHandlerDirective,
     LinkHandlerDirective,
     LoadingImageComponent,
     LoginComponent,

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,29 +1,30 @@
-import { AppComponent } from './app.component';
-import { AppRoutingModule } from './app-routing.module';
-import { ArtifactComponent } from './components/artifact/artifact.component';
-import { ArtifactListComponent } from './components/artifact-list/artifact-list.component';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { HttpClientModule } from '@angular/common/http';
+import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { CharacterComponent } from './components/character/character.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { AppRoutingModule } from './app-routing.module';
+import { AppComponent } from './app.component';
+import { ArtifactListComponent } from './components/artifact-list/artifact-list.component';
+import { ArtifactComponent } from './components/artifact/artifact.component';
+import { CharacterCardComponent } from './components/character-card/character-card.component';
 import { CharacterListComponent } from './components/character-list/character-list.component';
+import { CharacterComponent } from './components/character/character.component';
 import { DropdownContentCardComponent } from './components/dropdown-content-card/dropdown-content-card.component';
 import { FooterComponent } from './components/footer/footer.component';
 import { HomeComponent } from './components/home/home.component';
-import { HttpClientModule } from '@angular/common/http';
-import { ImpactService } from './services/impact.service';
-import { LinkHandlerDirective } from './directives/link-handler/link-handler.directive';
 import { LoadingImageComponent } from './components/loading-image/loading-image.component';
 import { LoginComponent } from './components/login/login.component';
-import { MoeRarityComponent } from './components/rarity/rarity.component';
-import { MultiplierPipe } from './pipes/multiplier.pipe';
 import { NavComponent } from './components/nav/nav.component';
-import { NgModule } from '@angular/core';
+import { MoeRarityComponent } from './components/rarity/rarity.component';
 import { RouteButtonComponent } from './components/route-button/route-button.component';
 import { SignupComponent } from './components/signup/signup.component';
 import { StatisticsComponent } from './components/statistics/statistics.component';
-import { UtilityService } from './services/utility.service';
-import { WeaponComponent } from './components/weapon/weapon.component';
 import { WeaponListComponent } from './components/weapon-list/weapon-list.component';
+import { WeaponComponent } from './components/weapon/weapon.component';
+import { LinkHandlerDirective } from './directives/link-handler/link-handler.directive';
+import { MultiplierPipe } from './pipes/multiplier.pipe';
+import { ImpactService } from './services/impact.service';
+import { UtilityService } from './services/utility.service';
 
 const baseUrlProvider = {
   provide: 'BASE_URL',
@@ -36,7 +37,9 @@ const baseUrlProvider = {
     AppComponent,
     ArtifactComponent,
     ArtifactComponent,
+    ArtifactComponent,
     ArtifactListComponent,
+    CharacterCardComponent,
     CharacterComponent,
     CharacterListComponent,
     DropdownContentCardComponent,
@@ -44,12 +47,12 @@ const baseUrlProvider = {
     HomeComponent,
     LinkHandlerDirective,
     LinkHandlerDirective,
+    LinkHandlerDirective,
     LoadingImageComponent,
     LoginComponent,
     MoeRarityComponent,
     MultiplierPipe,
     NavComponent,
-    RouteButtonComponent,
     RouteButtonComponent,
     SignupComponent,
     StatisticsComponent,

--- a/src/app/components/character-card/character-card.component.html
+++ b/src/app/components/character-card/character-card.component.html
@@ -1,0 +1,16 @@
+<a class="character-profile-link" routerLink="formattedLink"></a>
+
+<div class="character-card-summary">
+  <div class="character-card-name">{{ character.name }}</div>
+  <moe-rarity [value]="character.rarity"></moe-rarity>
+</div>
+
+<div class="character-card-image" [ngStyle]="{
+  'background-image': 'url(' + character.imageUrl + ')'
+}">
+  <div class="character-card-hover-image" [ngStyle]="{
+    'background-image': 'url(' + formattedHoverImage + ')'
+  }"></div>
+</div>
+
+<img class="character-card-tier" [src]="formattedTierImage" />

--- a/src/app/components/character-card/character-card.component.html
+++ b/src/app/components/character-card/character-card.component.html
@@ -2,7 +2,7 @@
 
 <div class="character-card-summary">
   <div class="character-card-name">{{ character.name }}</div>
-  <moe-rarity [value]="character.rarity"></moe-rarity>
+  <moe-rarity *ngIf="character.rarity > 0" [value]="character.rarity"></moe-rarity>
 </div>
 
 <div class="character-card-image-container"  [ngStyle]="{
@@ -12,9 +12,10 @@
     'background-image': 'url(' + character.imageUrl + ')'
   }">
   </div>
-  <div class="character-card-hover-image" [ngStyle]="{
+  <div *ngIf="!!formattedHoverImage"
+       class="character-card-hover-image" [ngStyle]="{
       'background-image': 'url(' + formattedHoverImage + ')'
     }"></div>
 </div>
 
-<img class="character-card-tier" [src]="formattedTierImage" />
+<img *ngIf="!!formattedTierImage" class="character-card-tier" [src]="formattedTierImage" />

--- a/src/app/components/character-card/character-card.component.html
+++ b/src/app/components/character-card/character-card.component.html
@@ -1,4 +1,4 @@
-<a class="character-profile-link" routerLink="formattedLink"></a>
+<a class="character-profile-link" [routerLink]="formattedLink"></a>
 
 <div class="character-card-summary">
   <div class="character-card-name">{{ character.name }}</div>

--- a/src/app/components/character-card/character-card.component.html
+++ b/src/app/components/character-card/character-card.component.html
@@ -5,12 +5,16 @@
   <moe-rarity [value]="character.rarity"></moe-rarity>
 </div>
 
-<div class="character-card-image" [ngStyle]="{
-  'background-image': 'url(' + character.imageUrl + ')'
-}">
+<div class="character-card-image-container"  [ngStyle]="{
+    'background-image': 'url(' + character.imageUrl + ')'
+  }">
+  <div class="character-card-blur-image" [ngStyle]="{
+    'background-image': 'url(' + character.imageUrl + ')'
+  }">
+  </div>
   <div class="character-card-hover-image" [ngStyle]="{
-    'background-image': 'url(' + formattedHoverImage + ')'
-  }"></div>
+      'background-image': 'url(' + formattedHoverImage + ')'
+    }"></div>
 </div>
 
 <img class="character-card-tier" [src]="formattedTierImage" />

--- a/src/app/components/character-card/character-card.component.scss
+++ b/src/app/components/character-card/character-card.component.scss
@@ -1,0 +1,51 @@
+@import "constants";
+
+:host {
+  display: flex;
+  flex-direction: row;
+  padding: 1em;
+  position: relative;
+}
+
+.character-profile-link {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.character-card-summary {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  justify-content: center;
+  padding: 0.5em;
+  text-align: center;
+}
+
+.character-card-name {
+  line-height: 1.4rem;
+}
+
+moe-rarity {
+  padding-top: 4px;
+}
+
+.character-card-image {
+  @include default-border-radius;
+
+  background-position: center;
+  background-size: cover;
+  height: 8em;
+  width: 8em;
+}
+
+.character-card-tier {
+  bottom: 0.5em;
+  height: 1.5em;
+  position: absolute;
+  right: 0.5em;
+  width: 1.5em;
+}

--- a/src/app/components/character-card/character-card.component.scss
+++ b/src/app/components/character-card/character-card.component.scss
@@ -65,13 +65,13 @@ moe-rarity {
 .character-card-blur-image,
 .character-card-hover-image {
   opacity: 0;
-  transition: 0.5s;
 }
 
 .character-card-blur-image {
   background-position: center;
   background-size: cover;
   height: 100%;
+  transition: 0.25s;
   width: 100%;
 }
 
@@ -83,6 +83,7 @@ moe-rarity {
   position: absolute;
   right: 0;
   top: 0;
+  transition: 0.5s;
 }
 
 .character-card-tier {

--- a/src/app/components/character-card/character-card.component.scss
+++ b/src/app/components/character-card/character-card.component.scss
@@ -35,7 +35,7 @@
   flex-direction: column;
   flex-grow: 1;
   justify-content: center;
-  padding: 0.5em;
+  padding: 0.5em 1em 0.5em 0;
   text-align: center;
 }
 
@@ -54,11 +54,12 @@ moe-rarity {
   background-size: cover;
   background-position: center;
   display: flex;
+  flex-shrink: 0;
   height: 8em;
   justify-content: center;
   overflow: hidden;
   position: relative;
-  width: 8em;
+  width: 7em;
 }
 
 .character-card-blur-image,

--- a/src/app/components/character-card/character-card.component.scss
+++ b/src/app/components/character-card/character-card.component.scss
@@ -1,6 +1,8 @@
 @import "constants";
 
 :host {
+  @include default-border-radius;
+
   cursor: pointer;
   display: flex;
   flex-direction: row;

--- a/src/app/components/character-card/character-card.component.scss
+++ b/src/app/components/character-card/character-card.component.scss
@@ -26,6 +26,7 @@
   position: absolute;
   right: 0;
   top: 0;
+  z-index: 10;
 }
 
 .character-card-summary {

--- a/src/app/components/character-card/character-card.component.scss
+++ b/src/app/components/character-card/character-card.component.scss
@@ -34,12 +34,12 @@
   flex-direction: column;
   flex-grow: 1;
   justify-content: center;
-  padding: 0.5em 1em 0.5em 0;
+  padding: 1em;
   text-align: center;
 }
 
 .character-card-name {
-  line-height: 1.4rem;
+  font-size: 0.875rem;
 }
 
 moe-rarity {
@@ -47,18 +47,17 @@ moe-rarity {
 }
 
 .character-card-image-container {
-  @include default-border-radius;
-
   align-items: center;
   background-size: cover;
   background-position: center;
+  border-radius: 0 $moe-border-radius $moe-border-radius 0;
   display: flex;
   flex-shrink: 0;
   height: 8em;
   justify-content: center;
   overflow: hidden;
   position: relative;
-  width: 7em;
+  width: 8em;
 }
 
 .character-card-blur-image,
@@ -86,9 +85,9 @@ moe-rarity {
 }
 
 .character-card-tier {
-  bottom: 0.5em;
+  bottom: 0.25em;
   height: 1.5em;
   position: absolute;
-  right: 0.5em;
+  right: 0.25em;
   width: 1.5em;
 }

--- a/src/app/components/character-card/character-card.component.scss
+++ b/src/app/components/character-card/character-card.component.scss
@@ -1,10 +1,23 @@
 @import "constants";
 
 :host {
+  cursor: pointer;
   display: flex;
   flex-direction: row;
   padding: 1em;
   position: relative;
+
+  &:hover {
+    .character-card-blur-image {
+      filter: blur(2px);
+      transform: scale(1.05);
+      opacity: 1;
+    }
+
+    .character-card-hover-image {
+      opacity: 1;
+    }
+  }
 }
 
 .character-profile-link {
@@ -33,13 +46,41 @@ moe-rarity {
   padding-top: 4px;
 }
 
-.character-card-image {
+.character-card-image-container {
   @include default-border-radius;
 
+  align-items: center;
+  background-size: cover;
+  background-position: center;
+  display: flex;
+  height: 8em;
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+  width: 8em;
+}
+
+.character-card-blur-image,
+.character-card-hover-image {
+  opacity: 0;
+  transition: 0.5s;
+}
+
+.character-card-blur-image {
   background-position: center;
   background-size: cover;
-  height: 8em;
-  width: 8em;
+  height: 100%;
+  width: 100%;
+}
+
+.character-card-hover-image {
+  background-position: center;
+  background-repeat: no-repeat;
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
 }
 
 .character-card-tier {

--- a/src/app/components/character-card/character-card.component.scss
+++ b/src/app/components/character-card/character-card.component.scss
@@ -4,7 +4,6 @@
   cursor: pointer;
   display: flex;
   flex-direction: row;
-  padding: 1em;
   position: relative;
 
   &:hover {
@@ -44,7 +43,7 @@
 }
 
 moe-rarity {
-  padding-top: 4px;
+  padding-top: 0.25em;
 }
 
 .character-card-image-container {

--- a/src/app/components/character-card/character-card.component.spec.ts
+++ b/src/app/components/character-card/character-card.component.spec.ts
@@ -1,0 +1,94 @@
+import { MoeRarityStubComponent } from '@/components/rarity/rarity.component.stub';
+import { RouterTestingModule } from '@angular/router/testing';
+import { CharacterCardComponent } from './character-card.component';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { CharacterCardModel } from './character-card.model';
+import { Element } from '@/enums/element.enum';
+
+describe('CharacterCardComponent', () => {
+  let fixture: ComponentFixture<CharacterCardComponent>;
+  let component: CharacterCardComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [MoeRarityStubComponent, CharacterCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CharacterCardComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should float the correct url over the card', waitForAsync(() => {
+    const characterModel = new CharacterCardModel.Builder('hu-tao').build();
+    component.character = characterModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.character-profile-link').href).toContain('/characters/hu-tao');
+  }));
+
+  it('should display the expected character name', waitForAsync(() => {
+    const characterModel = new CharacterCardModel.Builder('hu-tao').setName('Hu Tao').build();
+    component.character = characterModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.character-card-name').textContent).toContain('Hu Tao');
+  }));
+
+  it('should not display the rarity if not set', waitForAsync(() => {
+    const characterModel = new CharacterCardModel.Builder('hu-tao').build();
+    component.character = characterModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('moe-rarity')).toBeFalsy();
+  }));
+
+  it('should display the rarity when positive', waitForAsync(() => {
+    const characterModel = new CharacterCardModel.Builder('hu-tao').setRarity(1).build();
+    component.character = characterModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('moe-rarity')).toBeTruthy();
+  }));
+
+  it('should display the image as a background image', waitForAsync(() => {
+    const characterModel = new CharacterCardModel.Builder('hu-tao').setImageUrl('portrait.webp').build();
+    component.character = characterModel;
+    fixture.detectChanges();
+
+    const backgroundImage = fixture.nativeElement.querySelector('.character-card-image-container').style.backgroundImage;
+    expect(backgroundImage).toContain('portrait.webp');
+  }));
+
+  it('should not display the element hover image if not set', waitForAsync(() => {
+    const characterModel = new CharacterCardModel.Builder('hu-tao').build();
+    component.character = characterModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.character-card-hover-image')).toBeFalsy();
+  }));
+
+  it('should display the element hover image when set', waitForAsync(() => {
+    const characterModel = new CharacterCardModel.Builder('hu-tao').setElement(Element.Pyro).build();
+    component.character = characterModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.character-card-hover-image')).toBeTruthy();
+  }));
+
+  it('should not display the tier if not set', waitForAsync(() => {
+    const characterModel = new CharacterCardModel.Builder('hu-tao').build();
+    component.character = characterModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.character-card-tier')).toBeFalsy();
+  }));
+
+  it('should display the tier when set', waitForAsync(() => {
+    const characterModel = new CharacterCardModel.Builder('hu-tao').setTier('S').build();
+    component.character = characterModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.character-card-tier')).toBeTruthy();
+  }));
+});

--- a/src/app/components/character-card/character-card.component.ts
+++ b/src/app/components/character-card/character-card.component.ts
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview A card to display the summary of a character.
+ */
+
+import { Component, Input } from '@angular/core';
+import { CharacterCardModel } from './character-card.model';
+import { UtilityService } from '@/services/utility.service';
+
+@Component({
+  selector: 'moe-character-card',
+  templateUrl: './character-card.component.html',
+  styleUrls: ['./character-card.component.scss']
+})
+export class CharacterCardComponent {
+  @Input() character!: CharacterCardModel;
+
+  constructor(private utilityService: UtilityService) { }
+
+  get formattedLink() {
+    return `/characters/${this.character.id}`;
+  }
+
+  get formattedHoverImage() {
+    if (!this.character || !this.character.element) return '';
+
+    return this.utilityService.getElementImage(this.character.element);
+  }
+
+  get formattedTierImage() {
+    if (!this.character || !this.character.tier) return '';
+
+    return this.utilityService.getTierImage32(this.character.tier);
+  }
+}

--- a/src/app/components/character-card/character-card.model.ts
+++ b/src/app/components/character-card/character-card.model.ts
@@ -1,0 +1,85 @@
+import { Region } from '@/enums/region.enum';
+import { Element } from '@/enums/element.enum';
+
+export class CharacterCardModel {
+  readonly id: string;
+  readonly name: string;
+  readonly rarity: number;
+  readonly imageUrl?: string;
+  readonly element?: Element;
+  readonly tier?: string;
+
+  constructor(builder: CharacterCardModel.Builder) {
+    this.id = builder.getId();
+    this.name = builder.getName() || 'Unknown';
+    this.rarity = builder.getRarity() || 0;
+    this.imageUrl = builder.getImageUrl();
+    this.element = builder.getElement();
+    this.tier = builder.getTier();
+  }
+}
+
+export namespace CharacterCardModel {
+  export class Builder {
+    private name?: string;
+    private rarity?: number;
+    private imageUrl?: string;
+    private element?: Element;
+    private tier?: string;
+
+    constructor(private id: string) { }
+
+    setName(name: string) {
+      this.name = name;
+      return this;
+    }
+
+    setRarity(rarity: number) {
+      this.rarity = rarity;
+      return this;
+    }
+
+    setImageUrl(imageUrl: string) {
+      this.imageUrl = imageUrl;
+      return this;
+    }
+
+    setElement(element: Element) {
+      this.element = element;
+      return this;
+    }
+
+    setTier(tier: string) {
+      this.tier = tier;
+      return this;
+    }
+
+    build() {
+      return new CharacterCardModel(this);
+    }
+
+    getId() {
+      return this.id;
+    }
+
+    getName() {
+      return this.name;
+    }
+
+    getRarity() {
+      return this.rarity;
+    }
+
+    getImageUrl() {
+      return this.imageUrl;
+    }
+
+    getElement() {
+      return this.element;
+    }
+
+    getTier() {
+      return this.tier;
+    }
+  }
+}

--- a/src/app/components/character-list/character-list.component.html
+++ b/src/app/components/character-list/character-list.component.html
@@ -14,7 +14,7 @@
   </div>
 
   <!-- Loading state -->
-  <moe-loading-image *ngIf="!listItems"></moe-loading-image>
+  <moe-loading-image *ngIf="!listItems; else elseBlock"></moe-loading-image>
 
   <!-- List contents -->
   <ng-template #elseBlock>

--- a/src/app/components/character-list/character-list.component.html
+++ b/src/app/components/character-list/character-list.component.html
@@ -54,55 +54,10 @@
             </h3>
           </div>
           <div class="character-items-container flex-row flex-center">
-            <a
-              class="character-item-container flex-row background-gray-1"
-              [style]="characterItemContainerStyle"
-              *ngFor="let characterItem of listItem.value.characters"
-              routerLink="{{ '/characters/' + characterItem.Id }}"
-            >
-              <div class="character-item-title-container flex-column flex-center flex-center-items"
-                [style]="characterItemTitleStyle"
-              >
-                <h4>{{ characterItem.Name }}</h4>
-                <moe-rarity [value]="characterItem.Rarity"></moe-rarity>
-              </div>
-
-              <div class="character-item-image-container-1">
-                <div class="character-item-image-container-2">
-                  <div
-                    class="character-item-image-container-3 flex-row flex-center flex-center-items"
-                    [ngStyle]="{
-                      'background-image': 'url(' + characterItem.SquareCard + ')'
-                    }"
-                  >
-                    <div class="character-item-overlay-background-container">
-                      <div
-                        class="character-item-overlay"
-                        [ngStyle]="{
-                          'background-image':
-                            'url(' + characterItem.SquareCard + ')'
-                        }"
-                      ></div>
-                    </div>
-                    <div
-                      class="character-item-overlay-content flex-column flex-center flex-center-items position-absolute"
-                    >
-                      <img
-                        src="{{
-                          utilityService.getElementImage(characterItem.Element)
-                        }}"
-                      />
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <img
-                class="tier-image position-absolute"
-                [style]="characterItemTierStyle"
-                *ngIf="characterItem.Tier"
-                src="{{ utilityService.getTierImage32(characterItem.Tier) }}"
-              />
-            </a>
+            <moe-character-card
+              *ngFor="let characterResponse of listItem.value.characters"
+              [character]="characterResponse.toCharacterCardModel()">
+            </moe-character-card>
           </div>
         </div>
       </div>

--- a/src/app/components/character-list/character-list.component.html
+++ b/src/app/components/character-list/character-list.component.html
@@ -1,67 +1,42 @@
-<div class="container-1">
-  <div class="container-inner-1 flex-column">
-    <div class="banner-1">
-      <div class="banner-content-container-1">
-        <img
-          class="full-width full-height image-cover"
-          src="https://media.impact.moe/img/banners/banner-1.webp"
-        />
-      </div>
-      <div
-        class="banner-content-container-1 flex-column flex-center flex-center-items"
-      >
-        <h1>Characters</h1>
-        <a
-          id="group-type-button"
-          class="button-1 background-blue hover-background-gray"
-          (click)="groupButtonClick()"
-          ><i class="fas fa-chevron-right"></i>
-          <h2>{{ groupType }}</h2></a
-        >
-      </div>
-    </div>
-    <div class="body-1 flex-column flex-center-items full-width">
-      <div id="character-list-container" class="flex-column" *ngIf="listItems">
-        <div id="character-list-controls-container">
-          <div class="flex-row">
-            <a class="button-1 hover-background-gray-4" (click)="toggleCharacterItemsCollapsed()">
-              <p>{{ characterItemsCollapseButtonContent }}</p>
-            </a>
-          </div>
-        </div>
-        <div
-          class="character-group-list-item flex-column background-gray-2"
-          *ngFor="let listItem of listItems | keyvalue"
-        >
-          <div
-            class="character-group-list-item-image-container flex-row flex-center flex-center-items"
-            [ngClass]="
-              groupType === 'tier'
-                ? 'background-tier-' + listItem.key
-                : 'background-gray-3'
-            "
-          >
-            <img
-              *ngIf="listItem.value.mainImage"
-              src="{{ listItem.value.mainImage }}"
-              [ngStyle]="{
-                'margin-left': groupType === 'tier' ? '0em' : '2em',
-                'margin-right': groupType === 'tier' ? '0em' : '2em'
-              }"
-            />
-            <h3 *ngIf="listItem.value.mainLabel">
-              {{ listItem.value.mainLabel }}
-            </h3>
-          </div>
-          <div class="character-items-container flex-row flex-center">
-            <moe-character-card
-              *ngFor="let characterResponse of listItem.value.characters"
-              [character]="characterResponse.toCharacterCardModel()">
-            </moe-character-card>
-          </div>
-        </div>
-      </div>
-      <moe-loading-image *ngIf="!listItems"></moe-loading-image>
-    </div>
+<div class="page-header">
+  <h1>Characters</h1>
+</div>
+
+<div class="page-content">
+  <div class="character-list-controls">
+    <a id="group-type-button"
+      class="button-1 background-blue hover-background-gray"
+      (click)="groupButtonClick()">
+      <span class="group-type-button-label">Group By</span>
+      <i class="fas fa-chevron-right"></i>
+      <span class="group-type-selected">{{ groupType }}</span>
+    </a>
   </div>
+
+  <!-- Loading state -->
+  <moe-loading-image *ngIf="!listItems"></moe-loading-image>
+
+  <!-- List contents -->
+  <ng-template #elseBlock>
+    <div class="character-group-section" *ngFor="let listItem of listItems | keyvalue">
+      <div class="character-group-section-header" [ngClass]="
+                  groupType === 'tier'
+                    ? 'background-tier-' + listItem.key
+                    : 'background-gray-3'
+                ">
+        <img *ngIf="listItem.value.mainImage" src="{{ listItem.value.mainImage }}" [ngStyle]="{
+                    'margin-left': groupType === 'tier' ? '0em' : '2em',
+                    'margin-right': groupType === 'tier' ? '0em' : '2em'
+                  }" />
+        <div *ngIf="listItem.value.mainLabel">
+          {{ listItem.value.mainLabel }}
+        </div>
+      </div>
+      <div class="character-items-list">
+        <moe-character-card *ngFor="let characterResponse of listItem.value.characters"
+          [character]="characterResponse.toCharacterCardModel()">
+        </moe-character-card>
+      </div>
+    </div>
+  </ng-template>
 </div>

--- a/src/app/components/character-list/character-list.component.scss
+++ b/src/app/components/character-list/character-list.component.scss
@@ -65,7 +65,7 @@
 /* List Content */
 
 .character-group-section {
-  padding-bottom: 24px;
+  padding-bottom: 1.5em;
 }
 
 .character-group-section-header {

--- a/src/app/components/character-list/character-list.component.scss
+++ b/src/app/components/character-list/character-list.component.scss
@@ -1,83 +1,106 @@
 @import "constants";
 
-h1 {
-  font-family: $default-font-family;
-  color: #fefefe;
-  font-size: 2.2rem;
-  font-weight: 800;
-  margin-bottom: 0;
-  margin-top: 0;
+:host {
+  display: block;
+  margin-top: 6em;
 }
 
-h2 {
-  font-family: $default-font-family;
-  color: #fefefe;
-  font-size: 0.8rem;
-  letter-spacing: 0.02em;
-  font-weight: 800;
-  margin-top: 0;
-  margin-bottom: 0;
+.page-header {
+  align-items: center;
+  background-image: url(https://media.impact.moe/img/banners/banner-1.webp);
+  background-size: cover;
+  background-position: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  padding: 2em 1em;
+
+  @media (min-width: 600px) {
+    padding: 4em 1em;
+  }
 }
 
-h3 {
-  font-family: $default-font-family;
-  color: #fefefe;
-  font-size: 0.8rem;
-  letter-spacing: 0.02em;
-  font-weight: 800;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-/* Banner */
-
-#group-type-button {
-  margin-top: 1em;
-}
-
-#character-list-controls-container {
+.page-content {
+  box-sizing: border-box;
+  margin: 0 auto;
+  max-width: 1024px;
+  padding: 0 0.5em;
   width: 100%;
+
+  @media (min-width: 600px) {
+    padding: 0 1.5em;
+  }
+}
+
+.character-list-controls {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  user-select: none;
+  padding: 0.5em 0;
+
+  #group-type-button {
+    margin: 0;
+  }
+
+  .group-type-button-label {
+    text-transform: uppercase;
+  }
+
+  i {
+    padding: 0 0.5em;
+    margin: 0;
+  }
+
+  .group-type-selected {
+    font-size: 0.875rem;
+    font-weight: 600;
+  }
+
+  @media (min-width: 600px) {
+    padding: 1em 0;
+  }
 }
 
 /* List Content */
 
-#character-list-container {
-  max-width: 70%;
+.character-group-section {
+  padding-bottom: 24px;
 }
 
-.character-group-list-item {
+.character-group-section-header {
   @include default-border-radius;
 
-  margin: 0.5em;
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  padding: 0.5em;
+  height: 2em;
+
+  img {
+    max-height: 100%;
+  }
 }
 
-.character-group-list-item-image-container {
-  border-radius: 5px 5px 0 0;
-  align-self: stretch;
-  height: 3em;
-}
+.character-items-list {
+  column-gap: 0.5em;
+  display: grid;
+  justify-items: stretch;
+  margin-top: 0.5em;
+  row-gap: 0.5em;
 
-.character-group-list-item-image-container img {
-  width: 2em;
-}
+  @media (min-width: 600px) and (max-width: 1023px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
 
-.character-items-container {
-  padding: 1em;
-  flex-wrap: wrap;
-  flex-grow: 1;
+  @media (min-width: 1024px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 moe-character-card {
   @include default-border-radius;
 
-  background: $moe-background-color;
-  margin: 1em;
-  min-width: 18em;
-  width: 18em;
-}
-
-@media screen and (max-width: 525px) {
-  #character-list-container {
-    max-width: 100%;
-  }
+  background: #aaa1;
 }

--- a/src/app/components/character-list/character-list.component.scss
+++ b/src/app/components/character-list/character-list.component.scss
@@ -12,6 +12,7 @@
   background-image: url(https://media.impact.moe/img/banners/banner-1.webp);
   background-size: cover;
   background-position: center;
+  cursor: default;
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -25,7 +26,7 @@
 .page-content {
   box-sizing: border-box;
   margin: 0 auto;
-  max-width: 1024px;
+  max-width: 1440px;
   padding: 0 0.5em;
   width: 100%;
 
@@ -98,8 +99,12 @@ $items-gutter: 0.5em;
     grid-template-columns: repeat(2, 1fr);
   }
 
-  @media (min-width: 1024px) {
+  @media (min-width: 1024px) and (max-width: 1439px) {
     grid-template-columns: repeat(3, 1fr);
+  }
+
+  @media (min-width: 1440px) {
+    grid-template-columns: repeat(4, 1fr);
   }
 }
 

--- a/src/app/components/character-list/character-list.component.scss
+++ b/src/app/components/character-list/character-list.component.scss
@@ -83,12 +83,14 @@
   }
 }
 
+$items-gutter: 0.5em;
+
 .character-items-list {
-  column-gap: 0.5em;
+  column-gap: $items-gutter;
   display: grid;
   justify-items: stretch;
-  margin-top: 0.5em;
-  row-gap: 0.5em;
+  padding-top: $items-gutter;
+  row-gap: $items-gutter;
 
   @media (min-width: 600px) and (max-width: 1023px) {
     grid-template-columns: repeat(2, 1fr);
@@ -100,7 +102,5 @@
 }
 
 moe-character-card {
-  @include default-border-radius;
-
   background: #aaa1;
 }

--- a/src/app/components/character-list/character-list.component.scss
+++ b/src/app/components/character-list/character-list.component.scss
@@ -1,4 +1,4 @@
-@import 'constants';
+@import "constants";
 
 h1 {
   font-family: $default-font-family;
@@ -29,16 +29,6 @@ h3 {
   margin-bottom: 0;
 }
 
-h4 {
-  font-family: $default-font-family;
-  color: #fefefe;
-  font-size: 0.8rem;
-  letter-spacing: 0.02em;
-  font-weight: 800;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
 /* Banner */
 
 #group-type-button {
@@ -49,8 +39,6 @@ h4 {
   width: 100%;
 }
 
-
-
 /* List Content */
 
 #character-list-container {
@@ -58,7 +46,8 @@ h4 {
 }
 
 .character-group-list-item {
-  border-radius: 5px;
+  @include default-border-radius;
+
   margin: 0.5em;
 }
 
@@ -78,105 +67,13 @@ h4 {
   flex-grow: 1;
 }
 
-.character-item-container {
-  border-radius: 5px;
+moe-character-card {
+  @include default-border-radius;
+
+  background: $moe-background-color;
   margin: 1em;
-  width: 18em;
   min-width: 18em;
-}
-
-.character-item-title-container {
-  flex-grow: 1;
-  margin: 1em;
-}
-
-.character-item-title-container i {
-  color: #fefefe;
-  font-size: 0.6rem;
-  margin: 0 0.1em;
-}
-
-.character-item-title-container h4 {
-  margin-bottom: 0.5em;
-  text-align: center;
-}
-
-.character-item-image-container-1 {
-  width: 6em;
-  height: 6em;
-  margin: 1em;
-}
-
-.character-item-image-container-2 {
-  overflow: hidden;
-  border-radius: 5px;
-}
-
-.character-item-image-container-3 {
-  width: 6em;
-  min-width: 6em;
-  height: 6em;
-  background-size: cover;
-  background-repeat: no-repeat;
-  transition: 0.5s;
-}
-
-.character-item-overlay-background-container {
-  width: 5.25em;
-  max-width: 5.25em;
-  height: 5.25em;
-  max-height: 5.25em;
-  border-radius: 5px;
-  opacity: 0;
-  transition: 0.5s;
-}
-
-.character-item-overlay {
-  width: 6em;
-  height: 6em;
-  margin-top: -0.5em;
-  margin-left: -0.5em;
-  filter: blur(7px);
-  background-size: cover;
-  background-repeat: no-repeat;
-}
-
-.character-item-overlay-content {
-  transition: 0.5s;
-  opacity: 0;
-}
-
-.character-item-overlay-content h4 {
-  color: #000000;
-  margin-bottom: 0.2em;
-}
-
-.character-item-overlay-content i {
-  color: #000000;
-  font-size: 0.8em;
-}
-
-.tier-image {
-  width: 1.5em;
-  height: 1.5em;
-  margin-left: 16em;
-  margin-top: 6em;
-}
-
-.character-item-container:hover .character-item-overlay-background-container {
-  opacity: 1;
-}
-
-.character-item-container:hover .character-item-image-container-3 {
-  transform: scale(1.2);
-}
-
-.character-item-container:hover .tier-image {
-  transform: scale(1);
-}
-
-.character-item-container:hover .character-item-overlay-content {
-  opacity: 1;
+  width: 18em;
 }
 
 @media screen and (max-width: 525px) {

--- a/src/app/components/character-list/character-list.component.scss
+++ b/src/app/components/character-list/character-list.component.scss
@@ -1,8 +1,10 @@
 @import "constants";
 
 :host {
+  box-sizing: border-box;
   display: block;
-  margin-top: 6em;
+  min-height: 100%;
+  padding-top: 6em;
 }
 
 .page-header {
@@ -13,10 +15,10 @@
   display: flex;
   flex-direction: row;
   justify-content: center;
-  padding: 2em 1em;
+  height: 8em;
 
   @media (min-width: 600px) {
-    padding: 4em 1em;
+    height: 12em;
   }
 }
 

--- a/src/app/components/rarity/rarity.component.stub.ts
+++ b/src/app/components/rarity/rarity.component.stub.ts
@@ -1,0 +1,10 @@
+/**
+ * @fileoverview Provides a testing stub for MoeRarityComponent.
+ */
+
+import { Component, Input } from '@angular/core';
+
+@Component({ selector: 'moe-rarity', template: '' })
+export class MoeRarityStubComponent {
+  @Input() rarity!: number;
+}

--- a/src/app/models/character.model.ts
+++ b/src/app/models/character.model.ts
@@ -1,3 +1,4 @@
+import { CharacterCardModel } from '@/components/character-card/character-card.model';
 import { Element } from '@/enums/element.enum';
 import { Region } from '@/enums/region.enum';
 import { CharacterOverview } from './character-overview.model';
@@ -74,5 +75,15 @@ export class Character {
         this.Roles.push(new Role(roleJson));
       }
     }
+  }
+
+  toCharacterCardModel() {
+    return new CharacterCardModel.Builder(this.Id)
+      .setName(this.Name)
+      .setRarity(this.Rarity)
+      .setImageUrl(this.SquareCard)
+      .setElement(this.Element)
+      .setTier(this.Tier)
+      .build();
   }
 }

--- a/src/styles/constants.scss
+++ b/src/styles/constants.scss
@@ -1,1 +1,3 @@
-@import 'constants/fonts'
+@import "constants/fonts";
+@import "constants/colors";
+@import "constants/borders";

--- a/src/styles/constants/borders.scss
+++ b/src/styles/constants/borders.scss
@@ -1,0 +1,5 @@
+$moe-border-radius: 5px;
+
+@mixin default-border-radius {
+  border-radius: $moe-border-radius;
+}

--- a/src/styles/constants/colors.scss
+++ b/src/styles/constants/colors.scss
@@ -1,0 +1,6 @@
+$moe-background-color: #1e1e1e;
+$moe-text-color: #fefefe;
+
+@mixin default-text-color {
+  color: $moe-text-color;
+}

--- a/src/styles/constants/fonts.scss
+++ b/src/styles/constants/fonts.scss
@@ -1,1 +1,7 @@
-$default-font-family: 'Montserrat', sans-serif;
+$default-font-family: "Montserrat", sans-serif;
+$default-font-bold-weight: 800;
+
+@mixin default-font-style {
+  font: $default-font-bold-weight 1rem/1.6 $default-font-family;
+  letter-spacing: 0.04rem;
+}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,35 +1,5 @@
-@import 'constants';
-
-body,
-html {
-  width: 100%;
-  max-width: 100%;
-  height: 100%;
-  background: #1e1e1e;
-  margin: 0px;
-  overflow-x: hidden;
-}
-
-body {
-  position: relative;
-}
-
-*:focus {
-  outline: none;
-}
-
-a {
-  text-decoration: none;
-}
-
-p {
-  font-family: $default-font-family;
-  color: #ededed;
-  font-size: 0.8rem;
-  letter-spacing: 0.04em;
-  line-height: 1.2rem;
-  font-weight: 600;
-}
+@import "constants";
+@import "html";
 
 /* Element Backgrounds */
 

--- a/src/styles/html.scss
+++ b/src/styles/html.scss
@@ -24,6 +24,11 @@ body {
   outline: none;
 }
 
+h1 {
+  font: $default-font-bold-weight 2.2rem/1.6 $default-font-family;
+  margin: 0;
+}
+
 a {
   text-decoration: none;
 }

--- a/src/styles/html.scss
+++ b/src/styles/html.scss
@@ -1,0 +1,38 @@
+@import "constants";
+
+body,
+html {
+  height: 100%;
+  margin: 0;
+  max-width: 100%;
+  overflow-x: hidden;
+  width: 100%;
+}
+
+html {
+  background: $moe-background-color;
+}
+
+body {
+  @include default-font-style;
+  @include default-text-color;
+
+  position: relative;
+}
+
+*:focus {
+  outline: none;
+}
+
+a {
+  text-decoration: none;
+}
+
+p {
+  font-family: $default-font-family;
+  color: #ededed;
+  font-size: 0.8rem;
+  letter-spacing: 0.04em;
+  line-height: 1.2rem;
+  font-weight: 600;
+}


### PR DESCRIPTION
Major page rework for /character-list. Includes:

1. Components for character cards
2. CSS grid layout with: one column for mobile, two for tablet, three for small desktop, four for large desktop
3. Simplified DOM structure overall

CSS should also get less chaotic as the UX gets standardized; didn't want to bite off too much at once.

Feel free to clone and play around or check out these demo gifs:

![gridrefactormobile](https://user-images.githubusercontent.com/52547470/119416825-5bc40500-bca9-11eb-8172-7fc62f0e5bdd.gif)
![gridrefactortablet](https://user-images.githubusercontent.com/52547470/119417481-bf026700-bcaa-11eb-852c-3d423193e6d0.gif)
![gridrefactordesktopsmall](https://user-images.githubusercontent.com/52547470/119417494-c164c100-bcaa-11eb-898a-8fc80a63af13.gif)
![gridrefactordesktoplarge](https://user-images.githubusercontent.com/52547470/119417500-c4f84800-bcaa-11eb-91f6-89a4b4ad1fbe.gif)
