### PR TITLE
refactor: color / size in rarity module

### DIFF
--- a/src/app/components/rarity/rarity.component.scss
+++ b/src/app/components/rarity/rarity.component.scss
@@ -1,5 +1,7 @@
+@import "constants";
+
 :host {
-  color: #fefefe;
-  font-size: 0.7rem;
+  color: $moe-rarity-color;
+  font-size: 0.75rem;
   letter-spacing: 0.15rem;
 }

--- a/src/styles/constants/colors.scss
+++ b/src/styles/constants/colors.scss
@@ -1,5 +1,6 @@
 $moe-background-color: #1e1e1e;
 $moe-text-color: #fefefe;
+$moe-rarity-color: #fbcc33;
 
 @mixin default-text-color {
   color: $moe-text-color;


### PR DESCRIPTION
Change the color of the rarity stars to match the in-game coloring, + use a more standardized font-size (0.75rem aka 12px).