### PR TITLE
refactor: weapon list page ft. css grid

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,6 +19,7 @@ import { MoeRarityComponent } from './components/rarity/rarity.component';
 import { RouteButtonComponent } from './components/route-button/route-button.component';
 import { SignupComponent } from './components/signup/signup.component';
 import { StatisticsComponent } from './components/statistics/statistics.component';
+import { WeaponCardComponent } from './components/weapon-card/weapon-card.component';
 import { WeaponListComponent } from './components/weapon-list/weapon-list.component';
 import { WeaponComponent } from './components/weapon/weapon.component';
 import { LinkHandlerDirective } from './directives/link-handler/link-handler.directive';
@@ -53,12 +54,8 @@ const baseUrlProvider = {
     SignupComponent,
     StatisticsComponent,
     WeaponComponent,
-    ArtifactComponent,
-    LinkHandlerDirective,
-    RouteButtonComponent,
-    MoeRarityComponent,
-    MultiplierPipe,
-    WeaponListComponent,
+    WeaponCardComponent,
+    WeaponListComponent
   ],
   imports: [
     AppRoutingModule,

--- a/src/app/components/character-card/character-card.component.scss
+++ b/src/app/components/character-card/character-card.component.scss
@@ -1,4 +1,4 @@
-@import "constants";
+@import "global";
 
 :host {
   @include default-border-radius;
@@ -22,11 +22,7 @@
 }
 
 .character-profile-link {
-  bottom: 0;
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
+  @include cover-element;
   z-index: 10;
 }
 

--- a/src/app/components/character-card/character-card.component.scss
+++ b/src/app/components/character-card/character-card.component.scss
@@ -32,7 +32,7 @@
   flex-direction: column;
   flex-grow: 1;
   justify-content: center;
-  padding: 1em;
+  padding: 1rem;
   text-align: center;
 }
 
@@ -41,7 +41,7 @@
 }
 
 moe-rarity {
-  padding-top: 0.25em;
+  padding-top: 0.25rem;
 }
 
 .character-card-image-container {
@@ -51,11 +51,11 @@ moe-rarity {
   border-radius: 0 $moe-border-radius $moe-border-radius 0;
   display: flex;
   flex-shrink: 0;
-  height: 8em;
+  height: 8rem;
   justify-content: center;
   overflow: hidden;
   position: relative;
-  width: 8em;
+  width: 8rem;
 }
 
 .character-card-blur-image,
@@ -83,9 +83,9 @@ moe-rarity {
 }
 
 .character-card-tier {
-  bottom: 0.25em;
-  height: 1.5em;
+  bottom: 0.25rem;
+  height: 1.5rem;
   position: absolute;
-  right: 0.25em;
-  width: 1.5em;
+  right: 0.25rem;
+  width: 1.5rem;
 }

--- a/src/app/components/character-list/character-list.component.html
+++ b/src/app/components/character-list/character-list.component.html
@@ -1,8 +1,8 @@
-<div class="page-header">
+<div class="list-page-header">
   <h1>Characters</h1>
 </div>
 
-<div class="page-content">
+<div class="list-page-content">
   <div class="character-list-controls">
     <a id="group-type-button"
       class="button-1 background-blue hover-background-gray"
@@ -22,7 +22,7 @@
       <div class="character-group-section-header" [ngClass]="
                   groupType === 'tier'
                     ? 'background-tier-' + listItem.key
-                    : 'background-gray-3'
+                    : 'level1-background'
                 ">
         <img *ngIf="listItem.value.mainImage" src="{{ listItem.value.mainImage }}" [ngStyle]="{
                     'margin-left': groupType === 'tier' ? '0em' : '2em',

--- a/src/app/components/character-list/character-list.component.scss
+++ b/src/app/components/character-list/character-list.component.scss
@@ -1,38 +1,7 @@
-@import "constants";
+@import "global";
 
 :host {
-  box-sizing: border-box;
-  display: block;
-  min-height: 100%;
-  padding-top: 6em;
-}
-
-.page-header {
-  align-items: center;
-  background-image: url(https://media.impact.moe/img/banners/banner-1.webp);
-  background-size: cover;
-  background-position: center;
-  cursor: default;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  height: 8em;
-
-  @media (min-width: 600px) {
-    height: 12em;
-  }
-}
-
-.page-content {
-  box-sizing: border-box;
-  margin: 0 auto;
-  max-width: 1440px;
-  padding: 0 0.5em;
-  width: 100%;
-
-  @media (min-width: 600px) {
-    padding: 0 1.5em;
-  }
+  @include list-page-host;
 }
 
 .character-list-controls {
@@ -109,5 +78,5 @@ $items-gutter: 0.5em;
 }
 
 moe-character-card {
-  background: #aaa1;
+  background: $moe-level1-color;
 }

--- a/src/app/components/rarity/rarity.component.scss
+++ b/src/app/components/rarity/rarity.component.scss
@@ -1,7 +1,7 @@
 @import "constants";
 
 :host {
-  color: $moe-rarity-color;
+  color: $moe-stars-color;
   font-size: 0.75rem;
   letter-spacing: 0.15rem;
 }

--- a/src/app/components/weapon-card/weapon-card.component.html
+++ b/src/app/components/weapon-card/weapon-card.component.html
@@ -1,0 +1,26 @@
+<a class="weapon-page-link" [routerLink]="formattedLink"></a>
+
+<div class="weapon-card-summary">
+  <div class="weapon-card-name">{{ weapon.name }}</div>
+  <moe-rarity *ngIf="weapon.rarity > 0" [value]="weapon.rarity"></moe-rarity>
+  <div class="weapon-details">
+    <div class="weapon-attribute">
+      <div class="weapon-base-attack-label">Base ATK</div>
+      <div class="weapon-base-attack-value">{{ weapon.baseAttack }}</div>
+    </div>
+  </div>
+</div>
+
+<div class="weapon-card-image-container"
+  [ngClass]="{
+    'rarity1-gradient': weapon.rarity === 1,
+    'rarity2-gradient': weapon.rarity === 2,
+    'rarity3-gradient': weapon.rarity === 3,
+    'rarity4-gradient': weapon.rarity === 4,
+    'rarity5-gradient': weapon.rarity === 5
+  }"
+  >
+  <div class="weapon-card-blur-image" [ngStyle]="{
+      'background-image': 'url(' + weapon.imageUrl + ')'
+    }"></div>
+</div>

--- a/src/app/components/weapon-card/weapon-card.component.html
+++ b/src/app/components/weapon-card/weapon-card.component.html
@@ -4,11 +4,14 @@
 
 <div class="weapon-card-content">
   <div class="weapon-card-summary">
-    <div class="weapon-details">
-      <div class="weapon-attribute">
-        <div class="weapon-attribute-label">Base ATK</div>
-        <div class="weapon-attribute-value">{{ weapon.baseAttack }}</div>
-      </div>
+    <div class="weapon-attribute">
+      <div class="weapon-attribute-label">Base ATK</div>
+      <div class="weapon-attribute-value">{{ weapon.baseAttack }}</div>
+    </div>
+
+    <div *ngIf="hasSubstat()" class="weapon-attribute">
+      <div class="weapon-attribute-label">{{ weapon.substatType }}</div>
+      <div class="weapon-attribute-value">{{ weapon.substatValue }}</div>
     </div>
 
     <moe-rarity *ngIf="weapon.rarity > 0" [value]="weapon.rarity"></moe-rarity>

--- a/src/app/components/weapon-card/weapon-card.component.html
+++ b/src/app/components/weapon-card/weapon-card.component.html
@@ -1,26 +1,30 @@
 <a class="weapon-page-link" [routerLink]="formattedLink"></a>
 
-<div class="weapon-card-summary">
-  <div class="weapon-card-name">{{ weapon.name }}</div>
-  <moe-rarity *ngIf="weapon.rarity > 0" [value]="weapon.rarity"></moe-rarity>
-  <div class="weapon-details">
-    <div class="weapon-attribute">
-      <div class="weapon-base-attack-label">Base ATK</div>
-      <div class="weapon-base-attack-value">{{ weapon.baseAttack }}</div>
-    </div>
-  </div>
-</div>
+<div class="weapon-card-name">{{ weapon.name }}</div>
 
-<div class="weapon-card-image-container"
-  [ngClass]="{
-    'rarity1-gradient': weapon.rarity === 1,
-    'rarity2-gradient': weapon.rarity === 2,
-    'rarity3-gradient': weapon.rarity === 3,
-    'rarity4-gradient': weapon.rarity === 4,
-    'rarity5-gradient': weapon.rarity === 5
-  }"
-  >
-  <div class="weapon-card-blur-image" [ngStyle]="{
-      'background-image': 'url(' + weapon.imageUrl + ')'
-    }"></div>
+<div class="weapon-card-content">
+  <div class="weapon-card-summary">
+    <div class="weapon-details">
+      <div class="weapon-attribute">
+        <div class="weapon-attribute-label">Base ATK</div>
+        <div class="weapon-attribute-value">{{ weapon.baseAttack }}</div>
+      </div>
+    </div>
+
+    <moe-rarity *ngIf="weapon.rarity > 0" [value]="weapon.rarity"></moe-rarity>
+  </div>
+
+  <div class="weapon-card-image-container"
+    [ngClass]="{
+      'rarity1-gradient': weapon.rarity === 1,
+      'rarity2-gradient': weapon.rarity === 2,
+      'rarity3-gradient': weapon.rarity === 3,
+      'rarity4-gradient': weapon.rarity === 4,
+      'rarity5-gradient': weapon.rarity === 5
+    }"
+    >
+    <div class="weapon-card-blur-image" [ngStyle]="{
+        'background-image': 'url(' + weapon.imageUrl + ')'
+      }"></div>
+  </div>
 </div>

--- a/src/app/components/weapon-card/weapon-card.component.html
+++ b/src/app/components/weapon-card/weapon-card.component.html
@@ -4,14 +4,14 @@
 
 <div class="weapon-card-content">
   <div class="weapon-card-summary">
-    <div class="weapon-attribute">
-      <div class="weapon-attribute-label">Base ATK</div>
-      <div class="weapon-attribute-value">{{ weapon.baseAttack }}</div>
+    <div class="weapon-base-attack-attribute">
+      <div class="weapon-base-attack-label">Base ATK</div>
+      <div class="weapon-base-attack-value">{{ weapon.baseAttack }}</div>
     </div>
 
-    <div *ngIf="hasSubstat()" class="weapon-attribute">
-      <div class="weapon-attribute-label">{{ weapon.substatType }}</div>
-      <div class="weapon-attribute-value">{{ weapon.substatValue }}</div>
+    <div *ngIf="hasSubstat()" class="weapon-substat-attribute">
+      <div class="weapon-substat-label">{{ weapon.substatType }}</div>
+      <div class="weapon-substat-value">{{ weapon.substatValue }}</div>
     </div>
 
     <moe-rarity *ngIf="weapon.rarity > 0" [value]="weapon.rarity"></moe-rarity>
@@ -19,7 +19,7 @@
 
   <div class="weapon-card-image-container"
     [ngClass]="{
-      'rarity1-gradient': weapon.rarity === 1,
+      'rarity1-gradient': !weapon.rarity || weapon.rarity === 1,
       'rarity2-gradient': weapon.rarity === 2,
       'rarity3-gradient': weapon.rarity === 3,
       'rarity4-gradient': weapon.rarity === 4,

--- a/src/app/components/weapon-card/weapon-card.component.scss
+++ b/src/app/components/weapon-card/weapon-card.component.scss
@@ -5,7 +5,7 @@
 
   cursor: pointer;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   position: relative;
 
   &:hover {
@@ -20,8 +20,19 @@
   z-index: 10;
 }
 
+.weapon-card-name {
+  padding: 0.75rem 1rem;
+}
+
+.weapon-card-content {
+  display: flex;
+  flex-direction: row;
+  height: 100%;
+}
+
 .weapon-card-summary {
   align-items: flex-start;
+  border-top: 1px solid #4a4a4a;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
@@ -38,7 +49,7 @@ moe-rarity {
 }
 
 .weapon-details {
-  align-items: flex-end;
+  align-items: flex-start;
   display: flex;
   flex-direction: row;
   flex-grow: 1;
@@ -49,25 +60,25 @@ moe-rarity {
   align-items: center;
   display: flex;
   flex-direction: row;
-}
 
-.weapon-base-attack-label {
+  .weapon-attribute-label {
   font-size: 0.75rem;
   font-weight: 400;
   padding-right: 0.5em;
-}
+  }
 
-.weapon-base-attack-value {
-  font-size: 0.875rem;
+  .weapon-attribute-value {
+    font-size: 0.875rem;
+  }
 }
 
 .weapon-card-image-container {
   align-items: center;
-  border-radius: 0 $moe-border-radius $moe-border-radius 0;
+  border-radius: 0 0 $moe-border-radius 0;
   display: flex;
   flex-shrink: 0;
-  height: 8em;
   justify-content: center;
+  min-height: 8em;
   overflow: hidden;
   position: relative;
   width: 8em;

--- a/src/app/components/weapon-card/weapon-card.component.scss
+++ b/src/app/components/weapon-card/weapon-card.component.scss
@@ -37,7 +37,7 @@
   flex-direction: column;
   flex-grow: 1;
   justify-content: flex-start;
-  padding: 0.75em 1em;
+  padding: 0.75rem 1rem;
 }
 
 .weapon-card-name {
@@ -45,13 +45,16 @@
 }
 
 moe-rarity {
-  padding-top: 0.25em;
+  align-items: flex-end;
+  display: flex;
+  flex-grow: 1;
+  padding: 0.25rem 0;
 }
 
 .weapon-details {
   align-items: flex-start;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   flex-grow: 1;
   width: 100%;
 }
@@ -64,7 +67,7 @@ moe-rarity {
   .weapon-attribute-label {
   font-size: 0.75rem;
   font-weight: 400;
-  padding-right: 0.5em;
+  padding-right: 0.5rem;
   }
 
   .weapon-attribute-value {
@@ -78,10 +81,10 @@ moe-rarity {
   display: flex;
   flex-shrink: 0;
   justify-content: center;
-  min-height: 8em;
+  min-height: 8rem;
   overflow: hidden;
   position: relative;
-  width: 8em;
+  width: 8rem;
 }
 
 .weapon-card-blur-image {

--- a/src/app/components/weapon-card/weapon-card.component.scss
+++ b/src/app/components/weapon-card/weapon-card.component.scss
@@ -59,20 +59,23 @@ moe-rarity {
   width: 100%;
 }
 
-.weapon-attribute {
+.weapon-base-attack-attribute,
+.weapon-substat-attribute {
   align-items: center;
   display: flex;
   flex-direction: row;
+}
 
-  .weapon-attribute-label {
+.weapon-base-attack-label,
+.weapon-substat-label {
   font-size: 0.75rem;
   font-weight: 400;
   padding-right: 0.5rem;
-  }
+}
 
-  .weapon-attribute-value {
-    font-size: 0.875rem;
-  }
+.weapon-base-attack-value,
+.weapon-substat-value {
+  font-size: 0.875rem;
 }
 
 .weapon-card-image-container {

--- a/src/app/components/weapon-card/weapon-card.component.scss
+++ b/src/app/components/weapon-card/weapon-card.component.scss
@@ -1,0 +1,86 @@
+@import "constants";
+
+:host {
+  @include default-border-radius;
+
+  cursor: pointer;
+  display: flex;
+  flex-direction: row;
+  position: relative;
+
+  &:hover {
+    .weapon-card-blur-image {
+      transform: scale(1.1);
+    }
+  }
+}
+
+.weapon-page-link {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 10;
+}
+
+.weapon-card-summary {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  justify-content: flex-start;
+  padding: 0.75em 1em;
+}
+
+.weapon-card-name {
+  font-size: 0.875rem;
+}
+
+moe-rarity {
+  padding-top: 0.25em;
+}
+
+.weapon-details {
+  align-items: flex-end;
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
+  width: 100%;
+}
+
+.weapon-attribute {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+}
+
+.weapon-base-attack-label {
+  font-size: 0.75rem;
+  font-weight: 400;
+  padding-right: 0.5em;
+}
+
+.weapon-base-attack-value {
+  font-size: 0.875rem;
+}
+
+.weapon-card-image-container {
+  align-items: center;
+  border-radius: 0 $moe-border-radius $moe-border-radius 0;
+  display: flex;
+  flex-shrink: 0;
+  height: 8em;
+  justify-content: center;
+  overflow: hidden;
+  position: relative;
+  width: 8em;
+}
+
+.weapon-card-blur-image {
+  background-position: center;
+  background-size: cover;
+  height: 100%;
+  transition: 0.25s;
+  width: 100%;
+}

--- a/src/app/components/weapon-card/weapon-card.component.scss
+++ b/src/app/components/weapon-card/weapon-card.component.scss
@@ -1,4 +1,4 @@
-@import "constants";
+@import "global";
 
 :host {
   @include default-border-radius;
@@ -16,11 +16,7 @@
 }
 
 .weapon-page-link {
-  bottom: 0;
-  left: 0;
-  position: absolute;
-  right: 0;
-  top: 0;
+  @include cover-element;
   z-index: 10;
 }
 

--- a/src/app/components/weapon-card/weapon-card.component.spec.ts
+++ b/src/app/components/weapon-card/weapon-card.component.spec.ts
@@ -1,0 +1,133 @@
+import { MoeRarityStubComponent } from '@/components/rarity/rarity.component.stub';
+import { RouterTestingModule } from '@angular/router/testing';
+import { WeaponCardComponent } from './weapon-card.component';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { WeaponCardModel } from './weapon-card.model';
+import { Element } from '@/enums/element.enum';
+
+describe('WeaponCardComponent', () => {
+  let fixture: ComponentFixture<WeaponCardComponent>;
+  let component: WeaponCardComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [MoeRarityStubComponent, WeaponCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WeaponCardComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should float the correct url over the card', waitForAsync(() => {
+    const weaponModel = new WeaponCardModel.Builder('aquila-favonia').build();
+    component.weapon = weaponModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.weapon-page-link').href).toContain('/weapons/aquila-favonia');
+  }));
+
+  it('should display the expected name', waitForAsync(() => {
+    const weaponModel = new WeaponCardModel.Builder('aquila-favonia').setName('Aquila Favonia').build();
+    component.weapon = weaponModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.weapon-card-name').textContent).toContain('Aquila Favonia');
+  }));
+
+  it('should always display a base attack value', waitForAsync(() => {
+    const weaponModel = new WeaponCardModel.Builder('aquila-favonia').build();
+    component.weapon = weaponModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.weapon-base-attack-value').textContent).toContain('0');
+  }));
+
+  it('should display the expected base attack value', waitForAsync(() => {
+    const weaponModel = new WeaponCardModel.Builder('aquila-favonia').setBaseAttack(999).build();
+    component.weapon = weaponModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.weapon-base-attack-value').textContent).toContain('999');
+  }));
+
+  it('should not display the substat if no values are set', waitForAsync(() => {
+    const weaponModel = new WeaponCardModel.Builder('aquila-favonia').build();
+    component.weapon = weaponModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.weapon-substat-attribute')).toBeFalsy();
+  }));
+
+  it('should not display the substat if only the type is set', waitForAsync(() => {
+    const weaponModel = new WeaponCardModel.Builder('aquila-favonia').setSubstatType('ATK %').build();
+    component.weapon = weaponModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.weapon-substat-attribute')).toBeFalsy();
+  }));
+
+  it('should not display the substat if only the value is set', waitForAsync(() => {
+    const weaponModel = new WeaponCardModel.Builder('aquila-favonia').setSubstatValue(100).build();
+    component.weapon = weaponModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.weapon-substat-attribute')).toBeFalsy();
+  }));
+
+  it('should the substat if the type is set and the value is greater than zero', waitForAsync(() => {
+    const weaponModel = new WeaponCardModel.Builder('aquila-favonia')
+      .setSubstatType('ATK %')
+      .setSubstatValue(100)
+      .build();
+    component.weapon = weaponModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.weapon-substat-attribute')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.weapon-substat-label').textContent).toContain('ATK %');
+    expect(fixture.nativeElement.querySelector('.weapon-substat-value').textContent).toContain('100');
+  }));
+
+  it('should not display the rarity if no value is set', waitForAsync(() => {
+    const weaponModel = new WeaponCardModel.Builder('aquila-favonia').build();
+    component.weapon = weaponModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('moe-rarity')).toBeFalsy();
+  }));
+
+  it('should display the rarity if value is greater than zero', waitForAsync(() => {
+    const weaponModel = new WeaponCardModel.Builder('aquila-favonia').setRarity(5).build();
+    component.weapon = weaponModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('moe-rarity')).toBeTruthy();
+  }));
+
+  it('should display the lowest rarity gradient if no value is set', waitForAsync(() => {
+    const weaponModel = new WeaponCardModel.Builder('aquila-favonia').build();
+    component.weapon = weaponModel;
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.rarity1-gradient')).toBeTruthy();
+  }));
+
+  it('should display the expected rarity gradient', waitForAsync(() => {
+    for (let x = 1; x <= 5; x++) {
+      const weaponModel = new WeaponCardModel.Builder('aquila-favonia').setRarity(x).build();
+      component.weapon = weaponModel;
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector(`.rarity${x}-gradient`)).toBeTruthy();
+    }
+  }));
+
+  it('should display the weapon image', waitForAsync(() => {
+    const weaponModel = new WeaponCardModel.Builder('aquila-favonia').setImageUrl('sword.webp').build();
+    component.weapon = weaponModel;
+    fixture.detectChanges();
+
+    const backgroundImage = fixture.nativeElement.querySelector('.weapon-card-blur-image').style.backgroundImage;
+    expect(backgroundImage).toContain('sword.webp');
+  }));
+});

--- a/src/app/components/weapon-card/weapon-card.component.ts
+++ b/src/app/components/weapon-card/weapon-card.component.ts
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview A card to display the summary of a weapon.
+ */
+
+import { Component, Input } from '@angular/core';
+import { WeaponCardModel } from './weapon-card.model';
+
+@Component({
+  selector: 'moe-weapon-card',
+  templateUrl: './weapon-card.component.html',
+  styleUrls: ['./weapon-card.component.scss']
+})
+export class WeaponCardComponent {
+  @Input() weapon!: WeaponCardModel;
+
+  get formattedLink() {
+    return `/weapons/${this.weapon.id}`;
+  }
+}

--- a/src/app/components/weapon-card/weapon-card.component.ts
+++ b/src/app/components/weapon-card/weapon-card.component.ts
@@ -16,4 +16,8 @@ export class WeaponCardComponent {
   get formattedLink() {
     return `/weapons/${this.weapon.id}`;
   }
+
+  hasSubstat() {
+    return !!this.weapon.substatType && this.weapon.substatValue > 0;
+  }
 }

--- a/src/app/components/weapon-card/weapon-card.model.ts
+++ b/src/app/components/weapon-card/weapon-card.model.ts
@@ -4,6 +4,8 @@ export class WeaponCardModel {
   readonly rarity: number;
   readonly imageUrl?: string;
   readonly baseAttack: number;
+  readonly substatType?: string;
+  readonly substatValue: number;
 
   constructor(builder: WeaponCardModel.Builder) {
     this.id = builder.getId();
@@ -11,6 +13,8 @@ export class WeaponCardModel {
     this.rarity = builder.getRarity() || 0;
     this.imageUrl = builder.getImageUrl();
     this.baseAttack = builder.getBaseAttack() || 0;
+    this.substatType = builder.getSubstatType();
+    this.substatValue = builder.getSubstatValue() || 0;
   }
 }
 
@@ -20,6 +24,8 @@ export namespace WeaponCardModel {
     private rarity?: number;
     private imageUrl?: string;
     private baseAttack?: number;
+    private substatType?: string;
+    private substatValue?: number;
 
     constructor(private id: string) { }
 
@@ -40,6 +46,16 @@ export namespace WeaponCardModel {
 
     setBaseAttack(baseAttack: number) {
       this.baseAttack = baseAttack;
+      return this;
+    }
+
+    setSubstatType(substatType: string) {
+      this.substatType = substatType;
+      return this;
+    }
+
+    setSubstatValue(substatValue: number) {
+      this.substatValue = substatValue;
       return this;
     }
 
@@ -65,6 +81,14 @@ export namespace WeaponCardModel {
 
     getBaseAttack() {
       return this.baseAttack;
+    }
+
+    getSubstatType() {
+      return this.substatType;
+    }
+
+    getSubstatValue() {
+      return this.substatValue;
     }
   }
 }

--- a/src/app/components/weapon-card/weapon-card.model.ts
+++ b/src/app/components/weapon-card/weapon-card.model.ts
@@ -1,0 +1,70 @@
+export class WeaponCardModel {
+  readonly id: string;
+  readonly name: string;
+  readonly rarity: number;
+  readonly imageUrl?: string;
+  readonly baseAttack: number;
+
+  constructor(builder: WeaponCardModel.Builder) {
+    this.id = builder.getId();
+    this.name = builder.getName() || 'Unknown';
+    this.rarity = builder.getRarity() || 0;
+    this.imageUrl = builder.getImageUrl();
+    this.baseAttack = builder.getBaseAttack() || 0;
+  }
+}
+
+export namespace WeaponCardModel {
+  export class Builder {
+    private name?: string;
+    private rarity?: number;
+    private imageUrl?: string;
+    private baseAttack?: number;
+
+    constructor(private id: string) { }
+
+    setName(name: string) {
+      this.name = name;
+      return this;
+    }
+
+    setRarity(rarity: number) {
+      this.rarity = rarity;
+      return this;
+    }
+
+    setImageUrl(imageUrl: string) {
+      this.imageUrl = imageUrl;
+      return this;
+    }
+
+    setBaseAttack(baseAttack: number) {
+      this.baseAttack = baseAttack;
+      return this;
+    }
+
+    build() {
+      return new WeaponCardModel(this);
+    }
+
+    getId() {
+      return this.id;
+    }
+
+    getName() {
+      return this.name;
+    }
+
+    getRarity() {
+      return this.rarity;
+    }
+
+    getImageUrl() {
+      return this.imageUrl;
+    }
+
+    getBaseAttack() {
+      return this.baseAttack;
+    }
+  }
+}

--- a/src/app/components/weapon-list/weapon-list.component.html
+++ b/src/app/components/weapon-list/weapon-list.component.html
@@ -1,75 +1,24 @@
-<div class="container-1">
-  <div class="container-inner-1 flex-column">
-    <div class="banner-1">
-      <div class="banner-content-container-1">
-        <img
-          class="full-width full-height image-cover"
-          src="https://media.impact.moe/img/banners/banner-1.webp"
-        />
-      </div>
-      <div
-        class="banner-content-container-1 flex-column flex-center flex-center-items"
-      >
-        <h1>Weapons</h1>
-      </div>
-    </div>
-    <div class="body-1 flex-column flex-center-items full-width">
-      <div id="weapon-list-container" class="flex-column" *ngIf="listItems">
-        <div
-          class="weapon-group-list-item flex-column background-gray-2"
-          *ngFor="let listItem of listItems | keyvalue"
-        >
-          <div
-            class="weapon-group-list-item-image-container flex-row flex-center flex-center-items background-gray-3"
-          >
-            <img
-              *ngIf="listItem.value.mainImage"
-              src="{{ listItem.value.mainImage }}"
-            />
-            <h3 *ngIf="listItem.value.mainLabel">
-              {{ listItem.value.mainLabel }}
-            </h3>
-          </div>
-          <div class="weapon-items-container flex-row flex-center">
-            <a
-              class="weapon-item-container flex-row background-gray-1"
-              *ngFor="let weaponItem of listItem.value.weapons"
-              routerLink="{{ '/weapons/' + weaponItem.Id }}"
-            >
-              <div
-                class="weapon-item-title-container flex-column flex-center flex-center-items"
-              >
-                <h4>{{ weaponItem?.Name }}</h4>
-                <moe-rarity [value]="weaponItem.Rarity"></moe-rarity>
-              </div>
+<div class="list-page-header">
+  <h1>Weapons</h1>
+</div>
 
-              <div class="weapon-item-image-container-1">
-                <div class="weapon-item-image-container-2">
-                  <div
-                    class="weapon-item-image-container-3 flex-row flex-center flex-center-items"
-                    [ngStyle]="{
-                      'background-image': 'url(' + weaponItem.Image + ')'
-                    }"
-                  >
-                    <div class="weapon-item-overlay-background-container">
-                      <div
-                        class="weapon-item-overlay"
-                        [ngStyle]="{
-                          'background-image': 'url(' + weaponItem?.Image + ')'
-                        }"
-                      ></div>
-                    </div>
-                    <div
-                      class="weapon-item-overlay-content flex-column flex-center flex-center-items position-absolute"
-                    ></div>
-                  </div>
-                </div>
-              </div>
-            </a>
-          </div>
-        </div>
+<div class="list-page-content">
+  <moe-loading-image *ngIf="!listItems; else elseBlock"></moe-loading-image>
+
+  <ng-template #elseBlock>
+    <div class="weapon-filter-sort-stub"></div>
+    <div class="weapon-group-section" *ngFor="let listItem of listItems | keyvalue">
+      <div class="weapon-group-section-header">
+        <img *ngIf="listItem.value.mainImage" src="{{ listItem.value.mainImage }}" />
+        <h3 *ngIf="listItem.value.mainLabel">
+          {{ listItem.value.mainLabel }}
+        </h3>
       </div>
-      <moe-loading-image *ngIf="!listItems"></moe-loading-image>
+      <div class="weapon-items-list">
+        <moe-weapon-card *ngFor="let weapon of listItem.value.weapons"
+          [weapon]="weapon.toWeaponCardModel()">
+        </moe-weapon-card>
+      </div>
     </div>
-  </div>
+  </ng-template>
 </div>

--- a/src/app/components/weapon-list/weapon-list.component.scss
+++ b/src/app/components/weapon-list/weapon-list.component.scss
@@ -1,166 +1,59 @@
-@import 'constants';
+@import "global";
 
-h1 {
-  font-family: $default-font-family;
-  color: #fefefe;
-  font-size: 2.2rem;
-  font-weight: 800;
-  margin-bottom: 0;
-  margin-top: 0;
+:host {
+  @include list-page-host;
 }
 
-h2 {
-  font-family: $default-font-family;
-  color: #fefefe;
-  font-size: 0.8rem;
-  letter-spacing: 0.02em;
-  font-weight: 800;
-  margin-top: 0;
-  margin-bottom: 0;
-}
+.weapon-filter-sort-stub {
+  height: 0.5em;
 
-h3 {
-  font-family: $default-font-family;
-  color: #fefefe;
-  font-size: 0.8rem;
-  letter-spacing: 0.02em;
-  font-weight: 800;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-h4 {
-  font-family: $default-font-family;
-  color: #fefefe;
-  font-size: 0.8rem;
-  letter-spacing: 0.02em;
-  font-weight: 800;
-  margin-top: 0;
-  margin-bottom: 0;
-}
-
-/* Banner */
-
-#group-type-button {
-  margin-top: 1em;
-}
-
-/* List Content */
-
-#weapon-list-container {
-  max-width: 70%;
-}
-
-.weapon-group-list-item {
-  border-radius: 5px;
-  margin: 0.5em;
-}
-
-.weapon-group-list-item-image-container {
-  border-radius: 5px 5px 0 0;
-  align-self: stretch;
-  height: 3em;
-}
-
-.weapon-group-list-item-image-container img {
-  width: 2em;
-}
-
-.weapon-items-container {
-  padding: 1em;
-  flex-wrap: wrap;
-  flex-grow: 1;
-}
-
-.weapon-item-container {
-  border-radius: 5px;
-  margin: 1em;
-  width: 18em;
-  min-width: 18em;
-}
-
-.weapon-item-title-container {
-  flex-grow: 1;
-  margin: 1em;
-}
-
-.weapon-item-title-container i {
-  color: #fefefe;
-  margin: 0 0.1em;
-  font-size: 0.6rem;
-}
-
-.weapon-item-title-container h4 {
-  margin-bottom: 0.5em;
-  text-align: center;
-}
-
-.weapon-item-title-container p {
-  text-align: center;
-  margin-top: 0;
-}
-
-.weapon-item-image-container-1 {
-  width: 6em;
-  height: 6em;
-  margin: 1em;
-}
-
-.weapon-item-image-container-2 {
-  overflow: hidden;
-  border-radius: 5px;
-}
-
-.weapon-item-image-container-3 {
-  width: 6em;
-  min-width: 6em;
-  height: 6em;
-  background-size: cover;
-  background-repeat: no-repeat;
-  transition: 0.5s;
-}
-
-.weapon-item-overlay-background-container {
-  width: 5.25em;
-  max-width: 5.25em;
-  height: 5.25em;
-  max-height: 5.25em;
-  border-radius: 5px;
-  opacity: 0;
-  transition: 0.5s;
-}
-
-.weapon-item-overlay {
-  width: 6em;
-  height: 6em;
-  margin-top: -0.5em;
-  margin-left: -0.5em;
-  filter: blur(7px);
-  background-size: cover;
-  background-repeat: no-repeat;
-}
-
-.weapon-item-overlay-content {
-  width: 6em;
-  height: 6em;
-  opacity: 0;
-  transition: 0.5s;
-}
-
-.weapon-item-container:hover .weapon-item-overlay-background-container {
-  opacity: 1;
-}
-
-.weapon-item-container:hover .weapon-item-image-container-3 {
-  transform: scale(1.2);
-}
-
-.weapon-item-container:hover .weapon-item-overlay-content {
-  opacity: 1;
-}
-
-@media screen and (max-width: 525px) {
-  #weapon-list-container {
-    max-width: 100%;
+  @media (min-width: 600px) {
+    height: 1.5em;
   }
+}
+
+.weapon-group-section {
+  padding-bottom: 1.5em;
+}
+
+.weapon-group-section-header {
+  @include default-border-radius;
+
+  align-items: center;
+  background: $moe-level1-color;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  padding: 0.5em;
+  height: 2em;
+
+  img {
+    max-height: 100%;
+  }
+}
+
+$items-gutter: 0.5em;
+
+.weapon-items-list {
+  column-gap: $items-gutter;
+  display: grid;
+  justify-items: stretch;
+  padding-top: $items-gutter;
+  row-gap: $items-gutter;
+
+  @media (min-width: 600px) and (max-width: 1023px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @media (min-width: 1024px) and (max-width: 1439px) {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  @media (min-width: 1440px) {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+moe-weapon-card {
+  background: $moe-level1-color;
 }

--- a/src/app/models/weapon.model.ts
+++ b/src/app/models/weapon.model.ts
@@ -47,6 +47,8 @@ export class Weapon {
       .setRarity(this.Rarity)
       .setImageUrl(this.Image)
       .setBaseAttack(this.BaseAtk)
+      .setSubstatType(this.SubStatType)
+      .setSubstatValue(this.SubStat)
       .build();
   }
 }

--- a/src/app/models/weapon.model.ts
+++ b/src/app/models/weapon.model.ts
@@ -1,6 +1,7 @@
 import { WeaponStat } from '@/models/weapon-stat.model';
 import { Rarity } from '@/enums/rarity.enum';
 import { WeaponType } from '@/enums/weapon-type.enum';
+import { WeaponCardModel } from '@/components/weapon-card/weapon-card.model';
 
 export class Weapon {
   Id: string;
@@ -38,5 +39,14 @@ export class Weapon {
         this.Stats.push(new WeaponStat(weaponStatJson));
       }
     }
+  }
+
+  toWeaponCardModel() {
+    return new WeaponCardModel.Builder(this.Id)
+      .setName(this.Name)
+      .setRarity(this.Rarity)
+      .setImageUrl(this.Image)
+      .setBaseAttack(this.BaseAtk)
+      .build();
   }
 }

--- a/src/styles/constants/colors.scss
+++ b/src/styles/constants/colors.scss
@@ -1,7 +1,16 @@
 $moe-background-color: #1e1e1e;
+$moe-level1-color: #2a2828;
+
 $moe-text-color: #fefefe;
-$moe-rarity-color: #fbcc33;
 
 @mixin default-text-color {
   color: $moe-text-color;
 }
+
+$moe-stars-color: #fbcc33;
+
+$moe-rarity1-gradient: radial-gradient(at bottom right, #88949d 5%, #505865 95%);
+$moe-rarity2-gradient: radial-gradient(at bottom right, #5b9069 5%, #46575c 95%);
+$moe-rarity3-gradient: radial-gradient(at bottom right, #4fa4b8 5%, #515475 95%);
+$moe-rarity4-gradient: radial-gradient(at bottom right, #ba8acd 5%, #5b5381 95%);
+$moe-rarity5-gradient: radial-gradient(at bottom right, #daa34f 5%, #6a5254 95%);;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,6 +1,12 @@
 @import "constants";
 @import "html";
 
+/* App component backgrounds. */
+
+.level1-background {
+  background: $moe-level1-color;
+}
+
 /* List page stylings. */
 
 @mixin list-page-host {
@@ -38,10 +44,14 @@
   }
 }
 
-/* App component backgrounds. */
+/* Cover element styles. */
 
-.level1-background {
-  background: $moe-level1-color;
+@mixin cover-element {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
 }
 
 /* Element Backgrounds */

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,6 +1,49 @@
 @import "constants";
 @import "html";
 
+/* List page stylings. */
+
+@mixin list-page-host {
+  box-sizing: border-box;
+  display: block;
+  min-height: 100%;
+  padding-top: 6rem;
+}
+
+.list-page-header {
+  align-items: center;
+  background-image: url(https://media.impact.moe/img/banners/banner-1.webp);
+  background-size: cover;
+  background-position: center;
+  cursor: default;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  height: 8rem;
+
+  @media (min-width: 600px) {
+    height: 12rem;
+  }
+}
+
+.list-page-content {
+  box-sizing: border-box;
+  margin: 0 auto;
+  max-width: 1440px;
+  padding: 0 0.5rem;
+  width: 100%;
+
+  @media (min-width: 600px) {
+    padding: 0 1.5rem;
+  }
+}
+
+/* App component backgrounds. */
+
+.level1-background {
+  background: $moe-level1-color;
+}
+
 /* Element Backgrounds */
 
 .background-pyro {
@@ -99,6 +142,28 @@
 
 .hover-background-rarity-1:hover {
   background: #474747;
+}
+
+/* Rarity gradient backgrounds. */
+
+.rarity1-gradient {
+  background: $moe-rarity1-gradient;
+}
+
+.rarity2-gradient {
+  background: $moe-rarity2-gradient;
+}
+
+.rarity3-gradient {
+  background: $moe-rarity3-gradient;
+}
+
+.rarity4-gradient {
+  background: $moe-rarity4-gradient;
+}
+
+.rarity5-gradient {
+  background: $moe-rarity5-gradient;
 }
 
 /* General Backgrounds */


### PR DESCRIPTION
Created component cards for weapon summaries and simplified the DOM structure, applying the same logic / stylings as on the character list page. Demo image attached below:

![weapons-page-rework](https://user-images.githubusercontent.com/52547470/119901008-2d893400-befa-11eb-92a8-fa54e65b563b.png)