### PR TITLE
fix: actually sort by rarity for weapons filtersort

### DIFF
--- a/src/app/components/weapon-card/weapon-summary.model.ts
+++ b/src/app/components/weapon-card/weapon-summary.model.ts
@@ -115,6 +115,7 @@ export namespace WeaponSummary {
   }
 
   export enum Sort {
+    NONE,
     RARITY_DESCENDING,
     BASE_ATK_DESCENDING,
     SUBSTAT_VALUE_DESCENDING,
@@ -130,12 +131,18 @@ export namespace WeaponSummary {
       case WeaponSummary.Sort.SUBSTAT_VALUE_DESCENDING:
         return WeaponSummary.Comparator.bySubstatValue;
       case WeaponSummary.Sort.ALPHABETICALLY:
-      default:
         return WeaponSummary.Comparator.byNameAlphabetically;
+      case WeaponSummary.Sort.NONE:
+      default:
+        return WeaponSummary.Comparator.noOp;
     }
   };
 
   export class Comparator {
+    static noOp(a: WeaponSummary, b: WeaponSummary): number {
+      return 0;
+    }
+
     static byRarity(a: WeaponSummary, b: WeaponSummary): number {
       if (a.rarity !== b.rarity) {
         return b.rarity - a.rarity;


### PR DESCRIPTION
In what can only be described as "a comedy of errors", the first weapon sort type in the enum set (rarity) was evaluating as false because the first implicit value is (obviously) the falsey value of zero. There are different ways to get around this (e.g. assign explicit values, make the check where this is happening === undefined) but one of the better standards is to use a NONE or similar falsey-sounding definition to capture the initial cursed state. I'm pairing this with a no-op comparator to make the outcome more logically consistent as well.