### PR TITLE
feat: filter sort on artifacts page

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,3 +1,4 @@
+import { ArtifactCardComponent } from './components/artifact-card/artifact-card.component';
 import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
@@ -38,6 +39,7 @@ const baseUrlProvider = {
   declarations: [
     AppComponent,
     ArtifactComponent,
+    ArtifactCardComponent,
     ArtifactListComponent,
     CharacterCardComponent,
     CharacterComponent,

--- a/src/app/components/artifact-card/artifact-card.component.html
+++ b/src/app/components/artifact-card/artifact-card.component.html
@@ -1,24 +1,30 @@
 <a class="artifact-page-link" [routerLink]="formattedLink"></a>
 
-<div class="artifact-card-details">
-  <div class="artifact-card-name">{{ artifact.name }}</div>
-  <moe-rarity [value]="artifact.rarity"></moe-rarity>
-</div>
+<div class="artifact-card-name">{{ artifact.name }}</div>
 
-<div
-  class="artifact-card-image-container"
-  [ngClass]="{
-    'rarity1-gradient': !artifact.rarity || artifact.rarity === 1,
-    'rarity2-gradient': artifact.rarity === 2,
-    'rarity3-gradient': artifact.rarity === 3,
-    'rarity4-gradient': artifact.rarity === 4,
-    'rarity5-gradient': artifact.rarity === 5
-  }"
->
+<div class="artifact-card-contents">
+  <div class="artifact-card-details">
+    <div class="artifact-card-set-title">{{ artifact.setTitle }}</div>
+    <div class="artifact-card-type-label">{{ artifact.type }}</div>
+
+    <moe-rarity [value]="artifact.rarity"></moe-rarity>
+  </div>
+
   <div
-    class="artifact-card-blur-image"
-    [ngStyle]="{
-      'background-image': 'url(' + artifact.imageUrl + ')'
+    class="artifact-card-image-container"
+    [ngClass]="{
+      'rarity1-gradient': !artifact.rarity || artifact.rarity === 1,
+      'rarity2-gradient': artifact.rarity === 2,
+      'rarity3-gradient': artifact.rarity === 3,
+      'rarity4-gradient': artifact.rarity === 4,
+      'rarity5-gradient': artifact.rarity === 5
     }"
-  ></div>
+  >
+    <div
+      class="artifact-card-blur-image"
+      [ngStyle]="{
+        'background-image': 'url(' + artifact.imageUrl + ')'
+      }"
+    ></div>
+  </div>
 </div>

--- a/src/app/components/artifact-card/artifact-card.component.html
+++ b/src/app/components/artifact-card/artifact-card.component.html
@@ -1,0 +1,24 @@
+<a class="artifact-page-link" [routerLink]="formattedLink"></a>
+
+<div class="artifact-card-details">
+  <div class="artifact-card-name">{{ artifact.name }}</div>
+  <moe-rarity [value]="artifact.rarity"></moe-rarity>
+</div>
+
+<div
+  class="artifact-card-image-container"
+  [ngClass]="{
+    'rarity1-gradient': !artifact.rarity || artifact.rarity === 1,
+    'rarity2-gradient': artifact.rarity === 2,
+    'rarity3-gradient': artifact.rarity === 3,
+    'rarity4-gradient': artifact.rarity === 4,
+    'rarity5-gradient': artifact.rarity === 5
+  }"
+>
+  <div
+    class="artifact-card-blur-image"
+    [ngStyle]="{
+      'background-image': 'url(' + artifact.imageUrl + ')'
+    }"
+  ></div>
+</div>

--- a/src/app/components/artifact-card/artifact-card.component.html
+++ b/src/app/components/artifact-card/artifact-card.component.html
@@ -7,7 +7,10 @@
     <div class="artifact-card-set-title">{{ artifact.setTitle }}</div>
     <div class="artifact-card-type-label">{{ artifact.type }}</div>
 
-    <moe-rarity [value]="artifact.rarity"></moe-rarity>
+    <moe-rarity
+      *ngIf="artifact.rarity > 0"
+      [value]="artifact.rarity"
+    ></moe-rarity>
   </div>
 
   <div
@@ -21,6 +24,7 @@
     }"
   >
     <div
+      *ngIf="!!artifact.imageUrl"
       class="artifact-card-blur-image"
       [ngStyle]="{
         'background-image': 'url(' + artifact.imageUrl + ')'

--- a/src/app/components/artifact-card/artifact-card.component.scss
+++ b/src/app/components/artifact-card/artifact-card.component.scss
@@ -1,0 +1,54 @@
+@import 'global';
+
+:host {
+  @include default-border-radius;
+
+  cursor: pointer;
+  display: flex;
+  flex-direction: row;
+  overflow: hidden;
+  position: relative;
+
+  &:hover {
+    .artifact-card-blur-image {
+      transform: scale(1.1);
+    }
+  }
+}
+
+.artifact-page-link {
+  @include cover-element;
+  z-index: 10;
+}
+
+.artifact-card-details {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  justify-content: center;
+  padding: 0.75rem 1rem;
+  text-align: center;
+}
+
+.artifact-card-name {
+  @include subtitle2-font;
+}
+
+moe-rarity {
+  padding-top: 0.25rem;
+}
+
+.artifact-card-image-container {
+  flex-shrink: 0;
+  height: 8rem;
+  width: 8rem;
+}
+
+.artifact-card-blur-image {
+  background-position: center;
+  background-size: cover;
+  height: 100%;
+  transition: 0.25s;
+  width: 100%;
+}

--- a/src/app/components/artifact-card/artifact-card.component.scss
+++ b/src/app/components/artifact-card/artifact-card.component.scss
@@ -5,7 +5,7 @@
 
   cursor: pointer;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   overflow: hidden;
   position: relative;
 
@@ -21,27 +21,43 @@
   z-index: 10;
 }
 
+.artifact-card-name {
+  @include subtitle2-font;
+
+  padding: 0.75rem 1rem;
+}
+
+.artifact-card-contents {
+  display: flex;
+  flex-direction: row;
+}
+
 .artifact-card-details {
-  align-items: center;
+  align-items: flex-start;
+  border-top: 1px solid #4a4a4a;
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-  justify-content: center;
+  justify-content: flex-start;
   padding: 0.75rem 1rem;
-  text-align: center;
 }
 
-.artifact-card-name {
+.artifact-card-set-title {
   @include subtitle2-font;
 }
 
+.artifact-card-type-label {
+  @include caption-font;
+}
+
 moe-rarity {
+  margin-top: auto;
   padding-top: 0.25rem;
 }
 
 .artifact-card-image-container {
   flex-shrink: 0;
-  height: 8rem;
+  min-height: 8rem;
   width: 8rem;
 }
 

--- a/src/app/components/artifact-card/artifact-card.component.spec.ts
+++ b/src/app/components/artifact-card/artifact-card.component.spec.ts
@@ -1,0 +1,163 @@
+import { MoeRarityStubComponent } from '@/components/rarity/rarity.component.stub';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ArtifactCardComponent } from './artifact-card.component';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { ArtifactSummary } from './artifact-summary.model';
+import { ArtifactType } from '@/enums/artifact-type.enum';
+
+describe('ArtifactCardComponent', () => {
+  let fixture: ComponentFixture<ArtifactCardComponent>;
+  let component: ArtifactCardComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [MoeRarityStubComponent, ArtifactCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ArtifactCardComponent);
+    component = fixture.componentInstance;
+  });
+
+  it(
+    'should float the correct url over the card',
+    waitForAsync(() => {
+      const artifactModel = new ArtifactSummary.Builder('1').build();
+      component.artifact = artifactModel;
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector('.artifact-page-link').href
+      ).toContain('/artifacts/1');
+    })
+  );
+
+  it(
+    'should display the artifact name',
+    waitForAsync(() => {
+      const artifactModel = new ArtifactSummary.Builder('1')
+        .setName('Royal Plume')
+        .build();
+      component.artifact = artifactModel;
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector('.artifact-card-name').textContent
+      ).toContain('Royal Plume');
+    })
+  );
+
+  it(
+    'should display the artifact set title',
+    waitForAsync(() => {
+      const artifactModel = new ArtifactSummary.Builder('1')
+        .setSetTitle('Noblesse Oblige')
+        .build();
+      component.artifact = artifactModel;
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector('.artifact-card-set-title')
+          .textContent
+      ).toContain('Noblesse Oblige');
+    })
+  );
+
+  it(
+    'should display the artifact type',
+    waitForAsync(() => {
+      const artifactModel = new ArtifactSummary.Builder('1')
+        .setType(ArtifactType.Flower)
+        .build();
+      component.artifact = artifactModel;
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector('.artifact-card-type-label')
+          .textContent
+      ).toContain('Flower of Life');
+    })
+  );
+
+  it(
+    'should not display the rarity when not set',
+    waitForAsync(() => {
+      const artifactModel = new ArtifactSummary.Builder('1').build();
+      component.artifact = artifactModel;
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('moe-rarity')).toBeFalsy();
+    })
+  );
+
+  it(
+    'should display the rarity when it exists',
+    waitForAsync(() => {
+      const artifactModel = new ArtifactSummary.Builder('1')
+        .setRarity(1)
+        .build();
+      component.artifact = artifactModel;
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.querySelector('moe-rarity')).toBeTruthy();
+    })
+  );
+
+  it(
+    'should display the lowest rarity gradient if no value is set',
+    waitForAsync(() => {
+      const artifactModel = new ArtifactSummary.Builder('1').build();
+      component.artifact = artifactModel;
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector('.rarity1-gradient')
+      ).toBeTruthy();
+    })
+  );
+
+  it(
+    'should display the expected rarity gradient',
+    waitForAsync(() => {
+      for (let x = 1; x <= 5; x++) {
+        const artifactModel = new ArtifactSummary.Builder('1')
+          .setRarity(x)
+          .build();
+        component.artifact = artifactModel;
+        fixture.detectChanges();
+
+        expect(
+          fixture.nativeElement.querySelector(`.rarity${x}-gradient`)
+        ).toBeTruthy();
+      }
+    })
+  );
+
+  it(
+    'should not display the artifact image if not set',
+    waitForAsync(() => {
+      const artifactModel = new ArtifactSummary.Builder('1').build();
+      component.artifact = artifactModel;
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector('.artifact-card-blur-image')
+      ).toBeFalsy();
+    })
+  );
+
+  it(
+    'should display the artifact image when set',
+    waitForAsync(() => {
+      const artifactModel = new ArtifactSummary.Builder('1')
+        .setImageUrl('artifact.webp')
+        .build();
+      component.artifact = artifactModel;
+      fixture.detectChanges();
+
+      expect(
+        fixture.nativeElement.querySelector('.artifact-card-blur-image')
+      ).toBeTruthy();
+    })
+  );
+});

--- a/src/app/components/artifact-card/artifact-card.component.ts
+++ b/src/app/components/artifact-card/artifact-card.component.ts
@@ -1,0 +1,19 @@
+/**
+ * @fileoverview A card to display the summary of an artifact.
+ */
+
+import { Component, Input } from '@angular/core';
+import { ArtifactSummary } from './artifact-summary.model';
+
+@Component({
+  selector: 'moe-artifact-card',
+  templateUrl: './artifact-card.component.html',
+  styleUrls: ['./artifact-card.component.scss'],
+})
+export class ArtifactCardComponent {
+  @Input() artifact!: ArtifactSummary;
+
+  get formattedLink() {
+    return `/artifacts/${this.artifact.id}`;
+  }
+}

--- a/src/app/components/artifact-card/artifact-summary.model.ts
+++ b/src/app/components/artifact-card/artifact-summary.model.ts
@@ -97,7 +97,7 @@ export namespace ArtifactSummary {
   export const getComparator = (sort: ArtifactSummary.Sort) => {
     switch (sort) {
       case ArtifactSummary.Sort.SET_ALPHABETICALLY:
-        return ArtifactSummary.Comparator.bySetName;
+        return ArtifactSummary.Comparator.bySetTitle;
       case ArtifactSummary.Sort.RARITY_DESCENDING:
         return ArtifactSummary.Comparator.byRarity;
       default:
@@ -127,29 +127,35 @@ export namespace ArtifactSummary {
       return 0;
     }
 
-    static bySetName(a: ArtifactSummary, b: ArtifactSummary) {
-      const setNameComparison = ArtifactSummary.Comparator.byOnlySetName(a, b);
+    static bySetTitle(a: ArtifactSummary, b: ArtifactSummary) {
+      const setTitleComparison = ArtifactSummary.Comparator.byOnlySetTitle(
+        a,
+        b
+      );
       const rarityComparison = ArtifactSummary.Comparator.byOnlyRarity(a, b);
 
-      return setNameComparison === 0
+      return setTitleComparison === 0
         ? rarityComparison == 0
           ? ArtifactSummary.Comparator.byType(a, b)
           : rarityComparison
-        : setNameComparison;
+        : setTitleComparison;
     }
 
-    static byOnlySetName(a: ArtifactSummary, b: ArtifactSummary) {
+    static byOnlySetTitle(a: ArtifactSummary, b: ArtifactSummary) {
       return a.setTitle.localeCompare(b.setTitle);
     }
 
     static byRarity(a: ArtifactSummary, b: ArtifactSummary) {
       const rarityComparison = ArtifactSummary.Comparator.byOnlyRarity(a, b);
-      const setNameComparison = ArtifactSummary.Comparator.byOnlySetName(a, b);
+      const setTitleComparison = ArtifactSummary.Comparator.byOnlySetTitle(
+        a,
+        b
+      );
 
       return rarityComparison == 0
-        ? setNameComparison == 0
+        ? setTitleComparison == 0
           ? ArtifactSummary.Comparator.byType(a, b)
-          : setNameComparison
+          : setTitleComparison
         : rarityComparison;
     }
 

--- a/src/app/components/artifact-card/artifact-summary.model.ts
+++ b/src/app/components/artifact-card/artifact-summary.model.ts
@@ -1,0 +1,62 @@
+export class ArtifactSummary {
+  readonly id: string;
+  readonly name: string;
+  readonly rarity: number;
+  readonly imageUrl?: string;
+
+  constructor(builder: ArtifactSummary.Builder) {
+    this.id = builder.getId();
+    this.name = builder.getName() || 'Unknown';
+    this.rarity = builder.getRarity() || 0;
+    this.imageUrl = builder.getImageUrl();
+  }
+
+  hasTextInName(text: string) {
+    return this.name.toLocaleLowerCase().includes(text.toLocaleLowerCase());
+  }
+}
+
+export namespace ArtifactSummary {
+  export class Builder {
+    private name?: string;
+    private rarity?: number;
+    private imageUrl?: string;
+
+    constructor(private id: string) {}
+
+    setName(name: string) {
+      this.name = name;
+      return this;
+    }
+
+    setRarity(rarity: number) {
+      this.rarity = rarity;
+      return this;
+    }
+
+    setImageUrl(imageUrl: string) {
+      this.imageUrl = imageUrl;
+      return this;
+    }
+
+    build() {
+      return new ArtifactSummary(this);
+    }
+
+    getId() {
+      return this.id;
+    }
+
+    getName() {
+      return this.name;
+    }
+
+    getRarity() {
+      return this.rarity;
+    }
+
+    getImageUrl() {
+      return this.imageUrl;
+    }
+  }
+}

--- a/src/app/components/artifact-card/artifact-summary.model.ts
+++ b/src/app/components/artifact-card/artifact-summary.model.ts
@@ -16,7 +16,7 @@ export class ArtifactSummary {
     this.type = builder.getType();
   }
 
-  hasTextInName(text: string) {
+  hasTextInSetOrName(text: string) {
     return (
       this.name.toLocaleLowerCase().includes(text.toLocaleLowerCase()) ||
       this.setTitle.toLocaleLowerCase().includes(text.toLocaleLowerCase())
@@ -90,8 +90,8 @@ export namespace ArtifactSummary {
 
   export enum Sort {
     NONE,
-    RARITY_DESCENDING,
     SET_ALPHABETICALLY,
+    RARITY_DESCENDING,
   }
 
   export const getComparator = (sort: ArtifactSummary.Sort) => {

--- a/src/app/components/artifact-card/artifact-summary.model.ts
+++ b/src/app/components/artifact-card/artifact-summary.model.ts
@@ -135,7 +135,7 @@ export namespace ArtifactSummary {
       const rarityComparison = ArtifactSummary.Comparator.byOnlyRarity(a, b);
 
       return setTitleComparison === 0
-        ? rarityComparison == 0
+        ? rarityComparison === 0
           ? ArtifactSummary.Comparator.byType(a, b)
           : rarityComparison
         : setTitleComparison;
@@ -152,8 +152,8 @@ export namespace ArtifactSummary {
         b
       );
 
-      return rarityComparison == 0
-        ? setTitleComparison == 0
+      return rarityComparison === 0
+        ? setTitleComparison === 0
           ? ArtifactSummary.Comparator.byType(a, b)
           : setTitleComparison
         : rarityComparison;

--- a/src/app/components/artifact-card/artifact-summary.model.ts
+++ b/src/app/components/artifact-card/artifact-summary.model.ts
@@ -1,24 +1,34 @@
+import { ArtifactType } from '@/enums/artifact-type.enum';
 export class ArtifactSummary {
   readonly id: string;
   readonly name: string;
+  readonly setTitle: string;
   readonly rarity: number;
   readonly imageUrl?: string;
+  readonly type?: ArtifactType;
 
   constructor(builder: ArtifactSummary.Builder) {
     this.id = builder.getId();
     this.name = builder.getName() || 'Unknown';
+    this.setTitle = builder.getSetTitle() || '';
     this.rarity = builder.getRarity() || 0;
     this.imageUrl = builder.getImageUrl();
+    this.type = builder.getType();
   }
 
   hasTextInName(text: string) {
-    return this.name.toLocaleLowerCase().includes(text.toLocaleLowerCase());
+    return (
+      this.name.toLocaleLowerCase().includes(text.toLocaleLowerCase()) ||
+      this.setTitle.toLocaleLowerCase().includes(text.toLocaleLowerCase())
+    );
   }
 }
 
 export namespace ArtifactSummary {
   export class Builder {
     private name?: string;
+    private setTitle?: string;
+    private type?: ArtifactType;
     private rarity?: number;
     private imageUrl?: string;
 
@@ -26,6 +36,16 @@ export namespace ArtifactSummary {
 
     setName(name: string) {
       this.name = name;
+      return this;
+    }
+
+    setSetTitle(setTitle: string) {
+      this.setTitle = setTitle;
+      return this;
+    }
+
+    setType(type: ArtifactType) {
+      this.type = type;
       return this;
     }
 
@@ -51,12 +71,97 @@ export namespace ArtifactSummary {
       return this.name;
     }
 
+    getSetTitle() {
+      return this.setTitle;
+    }
+
+    getType() {
+      return this.type;
+    }
+
     getRarity() {
       return this.rarity;
     }
 
     getImageUrl() {
       return this.imageUrl;
+    }
+  }
+
+  export enum Sort {
+    NONE,
+    RARITY_DESCENDING,
+    SET_ALPHABETICALLY,
+  }
+
+  export const getComparator = (sort: ArtifactSummary.Sort) => {
+    switch (sort) {
+      case ArtifactSummary.Sort.SET_ALPHABETICALLY:
+        return ArtifactSummary.Comparator.bySetName;
+      case ArtifactSummary.Sort.RARITY_DESCENDING:
+        return ArtifactSummary.Comparator.byRarity;
+      default:
+        return ArtifactSummary.Comparator.noOp;
+    }
+  };
+
+  export const getTypeValue = (type?: ArtifactType) => {
+    switch (type) {
+      case ArtifactType.Flower:
+        return 5;
+      case ArtifactType.Feather:
+        return 4;
+      case ArtifactType.Sands:
+        return 3;
+      case ArtifactType.Goblet:
+        return 2;
+      case ArtifactType.Circlet:
+        return 1;
+      default:
+        return 0;
+    }
+  };
+
+  export class Comparator {
+    static noOp(a: ArtifactSummary, b: ArtifactSummary) {
+      return 0;
+    }
+
+    static bySetName(a: ArtifactSummary, b: ArtifactSummary) {
+      const setNameComparison = ArtifactSummary.Comparator.byOnlySetName(a, b);
+      const rarityComparison = ArtifactSummary.Comparator.byOnlyRarity(a, b);
+
+      return setNameComparison === 0
+        ? rarityComparison == 0
+          ? ArtifactSummary.Comparator.byType(a, b)
+          : rarityComparison
+        : setNameComparison;
+    }
+
+    static byOnlySetName(a: ArtifactSummary, b: ArtifactSummary) {
+      return a.setTitle.localeCompare(b.setTitle);
+    }
+
+    static byRarity(a: ArtifactSummary, b: ArtifactSummary) {
+      const rarityComparison = ArtifactSummary.Comparator.byOnlyRarity(a, b);
+      const setNameComparison = ArtifactSummary.Comparator.byOnlySetName(a, b);
+
+      return rarityComparison == 0
+        ? setNameComparison == 0
+          ? ArtifactSummary.Comparator.byType(a, b)
+          : setNameComparison
+        : rarityComparison;
+    }
+
+    static byOnlyRarity(a: ArtifactSummary, b: ArtifactSummary) {
+      return b.rarity - a.rarity;
+    }
+
+    static byType(a: ArtifactSummary, b: ArtifactSummary) {
+      return (
+        ArtifactSummary.getTypeValue(b.type) -
+        ArtifactSummary.getTypeValue(a.type)
+      );
     }
   }
 }

--- a/src/app/components/artifact-card/artifact-summary.spec.ts
+++ b/src/app/components/artifact-card/artifact-summary.spec.ts
@@ -1,0 +1,104 @@
+import { ArtifactSummary } from '@/components/artifact-card/artifact-summary.model';
+import { waitForAsync } from '@angular/core/testing';
+
+describe('ArtifactSummary', () => {
+  const royalPlume = new ArtifactSummary.Builder('royal-plume')
+    .setName('Royal Plume')
+    .setSetTitle('Noblesse Oblige')
+    .build();
+
+  it(
+    'should match an empty string',
+    waitForAsync(() => {
+      expect(royalPlume.hasTextInSetOrName('')).toBe(true);
+    })
+  );
+
+  it(
+    'should match by name a string exactly',
+    waitForAsync(() => {
+      expect(royalPlume.hasTextInSetOrName('Royal Plume')).toBe(true);
+    })
+  );
+
+  it(
+    'should match by name if the text is in the middle of a string',
+    waitForAsync(() => {
+      expect(royalPlume.hasTextInSetOrName('Plu')).toBe(true);
+    })
+  );
+
+  it(
+    'should match by name without case sensitivity',
+    waitForAsync(() => {
+      expect(royalPlume.hasTextInSetOrName('royal plume')).toBe(true);
+    })
+  );
+
+  it(
+    'should match by set title a string exactly',
+    waitForAsync(() => {
+      expect(royalPlume.hasTextInSetOrName('Noblesse Oblige')).toBe(true);
+    })
+  );
+
+  it(
+    'should match by set title if the text is in the middle of a string',
+    waitForAsync(() => {
+      expect(royalPlume.hasTextInSetOrName('Obl')).toBe(true);
+    })
+  );
+
+  it(
+    'should match by set title without case sensitivity',
+    waitForAsync(() => {
+      expect(royalPlume.hasTextInSetOrName('noblesse oblige')).toBe(true);
+    })
+  );
+
+  describe('Comparator', () => {
+    it(
+      'should sort by rarity descending',
+      waitForAsync(() => {
+        const leastRare = new ArtifactSummary.Builder('artifact1')
+          .setRarity(1)
+          .build();
+        const avgRare = new ArtifactSummary.Builder('artifact2')
+          .setRarity(2)
+          .build();
+        const mostRare = new ArtifactSummary.Builder('artifact3')
+          .setRarity(3)
+          .build();
+
+        const sortedArray = [leastRare, avgRare, mostRare].sort(
+          ArtifactSummary.getComparator(ArtifactSummary.Sort.RARITY_DESCENDING)
+        );
+        expect(sortedArray[0]).toBe(mostRare);
+        expect(sortedArray[1]).toBe(avgRare);
+        expect(sortedArray[2]).toBe(leastRare);
+      })
+    );
+
+    it(
+      'should sort by set title alphabetically',
+      waitForAsync(() => {
+        const setA = new ArtifactSummary.Builder('artifact1')
+          .setSetTitle('A')
+          .build();
+        const setB = new ArtifactSummary.Builder('artifact2')
+          .setSetTitle('B')
+          .build();
+        const setZ = new ArtifactSummary.Builder('artifact3')
+          .setSetTitle('Z')
+          .build();
+
+        const sortedArray = [setB, setZ, setA].sort(
+          ArtifactSummary.getComparator(ArtifactSummary.Sort.RARITY_DESCENDING)
+        );
+        expect(sortedArray[0]).toBe(setA);
+        expect(sortedArray[1]).toBe(setB);
+        expect(sortedArray[2]).toBe(setZ);
+      })
+    );
+  });
+});

--- a/src/app/components/artifact-list/artifact-list.component.html
+++ b/src/app/components/artifact-list/artifact-list.component.html
@@ -1,75 +1,22 @@
-<div class="container-1">
-  <div class="container-inner-1 flex-column">
-    <div class="banner-1">
-      <div class="banner-content-container-1">
-        <img
-          class="full-width full-height image-cover"
-          src="https://media.impact.moe/img/banners/banner-1.webp"
-        />
-      </div>
-      <div
-        class="banner-content-container-1 flex-column flex-center flex-center-items"
-      >
-        <h1>Artifacts</h1>
-      </div>
-    </div>
-    <div class="body-1 flex-column flex-center-items full-width">
-      <div id="artifact-list-container" class="flex-column" *ngIf="listItems">
-        <div
-          class="artifact-group-list-item flex-column background-gray-2"
-          *ngFor="let listItem of listItems | keyvalue"
-        >
-          <div
-            class="artifact-group-list-item-image-container flex-row flex-center flex-center-items background-gray-3"
-          >
-            <img
-              *ngIf="listItem.value.mainImage"
-              src="{{ listItem.value.mainImage }}"
-            />
-            <h3 *ngIf="listItem.value.mainLabel">
-              {{ listItem.value.mainLabel }}
-            </h3>
-          </div>
-          <div class="artifact-items-container flex-row flex-center">
-            <a
-              class="artifact-item-container flex-row background-gray-1"
-              *ngFor="let artifactItem of listItem.value.artifacts"
-              routerLink="{{ '/artifacts/' + artifactItem.Id }}"
-            >
-              <div
-                class="artifact-item-title-container flex-column flex-center flex-center-items"
-              >
-                <h4>{{ artifactItem?.Name }}</h4>
-                <moe-rarity [value]="artifactItem.Rarity"></moe-rarity>
-              </div>
+<h1 class="list-page-header">Artifacts</h1>
 
-              <div class="artifact-item-image-container-1">
-                <div class="artifact-item-image-container-2">
-                  <div
-                    class="artifact-item-image-container-3 flex-row flex-center flex-center-items"
-                    [ngStyle]="{
-                      'background-image': 'url(' + artifactItem.Image + ')'
-                    }"
-                  >
-                    <div class="artifact-item-overlay-background-container">
-                      <div
-                        class="artifact-item-overlay"
-                        [ngStyle]="{
-                          'background-image': 'url(' + artifactItem?.Image + ')'
-                        }"
-                      ></div>
-                    </div>
-                    <div
-                      class="artifact-item-overlay-content flex-column flex-center flex-center-items position-absolute"
-                    ></div>
-                  </div>
-                </div>
-              </div>
-            </a>
-          </div>
-        </div>
-      </div>
-      <moe-loading-image *ngIf="!listItems"></moe-loading-image>
+<moe-loading-image *ngIf="!hasData(); else elseBlock"></moe-loading-image>
+
+<ng-template #elseBlock>
+  <div class="artifact-search-container">
+    <moe-filter-sort
+      [placeholderText]="placeholderText"
+      (filterSortEvent)="updateConfiguration($event)"
+    ></moe-filter-sort>
+  </div>
+
+  <div class="artifact-search-results">
+    <div class="artifact-results-message">{{ resultsMessage }}</div>
+    <div class="artifact-results-grid">
+      <moe-artifact-card
+        *ngFor="let artifact of results"
+        [artifact]="artifact"
+      ></moe-artifact-card>
     </div>
   </div>
-</div>
+</ng-template>

--- a/src/app/components/artifact-list/artifact-list.component.html
+++ b/src/app/components/artifact-list/artifact-list.component.html
@@ -6,6 +6,8 @@
   <div class="artifact-search-container">
     <moe-filter-sort
       [placeholderText]="placeholderText"
+      [filterOptions]="filterOptions"
+      [sortOptions]="sortOptions"
       (filterSortEvent)="updateConfiguration($event)"
     ></moe-filter-sort>
   </div>

--- a/src/app/components/artifact-list/artifact-list.component.scss
+++ b/src/app/components/artifact-list/artifact-list.component.scss
@@ -1,166 +1,36 @@
-@import 'constants';
+@import 'global';
 
-h1 {
-  font-family: $default-font-family;
-  color: #fefefe;
-  font-size: 2.2rem;
-  font-weight: 800;
-  margin-bottom: 0;
-  margin-top: 0;
+:host {
+  @include list-page-host;
 }
 
-h2 {
-  font-family: $default-font-family;
-  color: #fefefe;
-  font-size: 0.8rem;
-  letter-spacing: 0.02em;
-  font-weight: 800;
-  margin-top: 0;
-  margin-bottom: 0;
+.artifact-search-container {
+  background: $moe-background-color;
+  border-bottom: 1px solid $moe-level1-color;
 }
 
-h3 {
-  font-family: $default-font-family;
-  color: #fefefe;
-  font-size: 0.8rem;
-  letter-spacing: 0.02em;
-  font-weight: 800;
-  margin-top: 0;
-  margin-bottom: 0;
+moe-filter-sort {
+  @include list-page-sizing;
 }
 
-h4 {
-  font-family: $default-font-family;
-  color: #fefefe;
-  font-size: 0.8rem;
-  letter-spacing: 0.02em;
-  font-weight: 800;
-  margin-top: 0;
-  margin-bottom: 0;
-}
+.artifact-search-results {
+  @include list-page-sizing;
+  padding: 0 0.5rem 0.5rem;
 
-/* Banner */
-
-#group-type-button {
-  margin-top: 1em;
-}
-
-/* List Content */
-
-#artifact-list-container {
-  max-width: 70%;
-}
-
-.artifact-group-list-item {
-  border-radius: 5px;
-  margin: 0.5em;
-}
-
-.artifact-group-list-item-image-container {
-  border-radius: 5px 5px 0 0;
-  align-self: stretch;
-  height: 3em;
-}
-
-.artifact-group-list-item-image-container img {
-  width: 2em;
-}
-
-.artifact-items-container {
-  padding: 1em;
-  flex-wrap: wrap;
-  flex-grow: 1;
-}
-
-.artifact-item-container {
-  border-radius: 5px;
-  margin: 1em;
-  width: 18em;
-  min-width: 18em;
-}
-
-.artifact-item-title-container {
-  flex-grow: 1;
-  margin: 1em;
-}
-
-.artifact-item-title-container i {
-  color: #fefefe;
-  margin: 0 0.1em;
-  font-size: 0.6rem;
-}
-
-.artifact-item-title-container h4 {
-  margin-bottom: 0.5em;
-  text-align: center;
-}
-
-.artifact-item-title-container p {
-  text-align: center;
-  margin-top: 0;
-}
-
-.artifact-item-image-container-1 {
-  width: 6em;
-  height: 6em;
-  margin: 1em;
-}
-
-.artifact-item-image-container-2 {
-  overflow: hidden;
-  border-radius: 5px;
-}
-
-.artifact-item-image-container-3 {
-  width: 6em;
-  min-width: 6em;
-  height: 6em;
-  background-size: cover;
-  background-repeat: no-repeat;
-  transition: 0.5s;
-}
-
-.artifact-item-overlay-background-container {
-  width: 5.25em;
-  max-width: 5.25em;
-  height: 5.25em;
-  max-height: 5.25em;
-  border-radius: 5px;
-  opacity: 0;
-  transition: 0.5s;
-}
-
-.artifact-item-overlay {
-  width: 6em;
-  height: 6em;
-  margin-top: -0.5em;
-  margin-left: -0.5em;
-  filter: blur(7px);
-  background-size: cover;
-  background-repeat: no-repeat;
-}
-
-.artifact-item-overlay-content {
-  width: 6em;
-  height: 6em;
-  opacity: 0;
-  transition: 0.5s;
-}
-
-.artifact-item-container:hover .artifact-item-overlay-background-container {
-  opacity: 1;
-}
-
-.artifact-item-container:hover .artifact-item-image-container-3 {
-  transform: scale(1.2);
-}
-
-.artifact-item-container:hover .artifact-item-overlay-content {
-  opacity: 1;
-}
-
-@media screen and (max-width: 525px) {
-  #artifact-list-container {
-    max-width: 100%;
+  @media (min-width: $tablet-min-width) {
+    padding: 0 1.5rem 1.5rem;
   }
+}
+
+.artifact-results-message {
+  @include caption-font;
+  padding: 0.5rem 0.25rem;
+}
+
+.artifact-results-grid {
+  @include list-page-grid;
+}
+
+moe-artifact-card {
+  background: $moe-level1-color;
 }

--- a/src/app/components/artifact-list/artifact-list.component.ts
+++ b/src/app/components/artifact-list/artifact-list.component.ts
@@ -1,8 +1,26 @@
+import { ArtifactType } from './../../enums/artifact-type.enum';
 import { ArtifactSummary } from '@/components/artifact-card/artifact-summary.model';
-import { FilterSortConfiguration } from '@/components/filter-sort/filter-sort.component';
+import {
+  FilterSortConfiguration,
+  FilterSortOption,
+} from '@/components/filter-sort/filter-sort.component';
 import { ImpactService } from '@/services/impact.service';
 import { Component, OnInit } from '@angular/core';
 import { Artifact } from 'src/app/models/artifact.model';
+
+export const FILTER_OPTIONS: Array<FilterSortOption> = [
+  { label: 'All Types', value: undefined },
+  { label: 'Flowers', value: ArtifactType.Flower },
+  { label: 'Feathers', value: ArtifactType.Feather },
+  { label: 'Sands', value: ArtifactType.Sands },
+  { label: 'Goblets', value: ArtifactType.Goblet },
+  { label: 'Circlets', value: ArtifactType.Circlet },
+];
+
+export const SORT_OPTIONS: Array<FilterSortOption> = [
+  { label: 'Set Title (A->Z)', value: ArtifactSummary.Sort.SET_ALPHABETICALLY },
+  { label: 'Rarity', value: ArtifactSummary.Sort.RARITY_DESCENDING },
+];
 
 @Component({
   selector: 'app-artifact-list',
@@ -10,6 +28,9 @@ import { Artifact } from 'src/app/models/artifact.model';
   styleUrls: ['./artifact-list.component.scss'],
 })
 export class ArtifactListComponent implements OnInit {
+  readonly filterOptions = FILTER_OPTIONS;
+  readonly sortOptions = SORT_OPTIONS;
+
   private allData: Array<ArtifactSummary> = [];
   private currentConfig?: FilterSortConfiguration;
   private currentResults: Array<ArtifactSummary> = [];
@@ -31,14 +52,44 @@ export class ArtifactListComponent implements OnInit {
   }
 
   updateConfiguration(config: FilterSortConfiguration) {
-    let filteredResults: Array<ArtifactSummary> = this.allData;
+    let filteredResults: Array<ArtifactSummary> = this.isRefiningSearch(config)
+      ? this.currentResults
+      : this.allData;
+
+    const filterCategory = config.selectedFilter.value;
+    const sort = config.selectedSort.value;
+
+    if (filterCategory) {
+      filteredResults = filteredResults.filter(
+        item => item.type === filterCategory
+      );
+    }
 
     filteredResults = filteredResults.filter(item =>
       item.hasTextInName(config.filterText)
     );
 
+    if (sort) {
+      filteredResults = filteredResults.sort(
+        ArtifactSummary.getComparator(sort)
+      );
+    }
+
     this.currentConfig = config;
     this.currentResults = filteredResults;
+  }
+
+  /**
+   * Determines whether the given search configuration is a subset of the one
+   * we have stored locally.
+   */
+  private isRefiningSearch(config: FilterSortConfiguration) {
+    return (
+      !!this.currentConfig &&
+      !!config.filterText &&
+      config.filterText.includes(this.currentConfig.filterText) &&
+      config.selectedFilter === this.currentConfig.selectedFilter
+    );
   }
 
   get resultsMessage() {

--- a/src/app/components/artifact-list/artifact-list.component.ts
+++ b/src/app/components/artifact-list/artifact-list.component.ts
@@ -1,7 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import { ArtifactSummary } from '@/components/artifact-card/artifact-summary.model';
+import { FilterSortConfiguration } from '@/components/filter-sort/filter-sort.component';
 import { ImpactService } from '@/services/impact.service';
-import { UtilityService } from '@/services/utility.service';
-import { ArtifactType } from 'src/app/enums/artifact-type.enum';
+import { Component, OnInit } from '@angular/core';
 import { Artifact } from 'src/app/models/artifact.model';
 
 @Component({
@@ -10,42 +10,44 @@ import { Artifact } from 'src/app/models/artifact.model';
   styleUrls: ['./artifact-list.component.scss'],
 })
 export class ArtifactListComponent implements OnInit {
-  listItems?: { [key: string]: any };
-  groupType = '';
+  private allData: Array<ArtifactSummary> = [];
+  private currentConfig?: FilterSortConfiguration;
+  private currentResults: Array<ArtifactSummary> = [];
 
-  constructor(
-    private impactService: ImpactService,
-    public utilityService: UtilityService
-  ) {}
+  constructor(private impactService: ImpactService) {}
 
   ngOnInit() {
-    this.impactService.getArtifacts().subscribe((data: Array<Artifact>) => {
-      this.listItems = new Array();
-
-      this.listItems[ArtifactType.Circlet] = {
-        mainLabel: 'Circlet',
-        artifacts: new Array<Artifact>(),
-      };
-      this.listItems[ArtifactType.Feather] = {
-        mainLabel: 'Feather',
-        artifacts: new Array<Artifact>(),
-      };
-      this.listItems[ArtifactType.Flower] = {
-        mainLabel: 'Flower',
-        artifacts: new Array<Artifact>(),
-      };
-      this.listItems[ArtifactType.Goblet] = {
-        mainLabel: 'Goblet',
-        artifacts: new Array<Artifact>(),
-      };
-      this.listItems[ArtifactType.Sands] = {
-        mainLabel: 'Sands',
-        artifacts: new Array<Artifact>(),
-      };
-
-      for (const artifactItem of data) {
-        this.listItems[artifactItem.ArtifactType].artifacts.push(artifactItem);
-      }
+    this.impactService.getArtifacts().subscribe((next: Array<Artifact>) => {
+      this.allData = next.map(item => item.toArtifactSummary());
     });
+  }
+
+  get placeholderText() {
+    return 'Find an artifact by name…';
+  }
+
+  hasData() {
+    return !!this.allData && this.allData.length > 0;
+  }
+
+  updateConfiguration(config: FilterSortConfiguration) {
+    let filteredResults: Array<ArtifactSummary> = this.allData;
+
+    filteredResults = filteredResults.filter(item =>
+      item.hasTextInName(config.filterText)
+    );
+
+    this.currentConfig = config;
+    this.currentResults = filteredResults;
+  }
+
+  get resultsMessage() {
+    const plural = this.results.length === 1 ? '' : 's';
+
+    return `${this.results.length} result${plural}`;
+  }
+
+  get results() {
+    return this.currentResults;
   }
 }

--- a/src/app/components/artifact-list/artifact-list.component.ts
+++ b/src/app/components/artifact-list/artifact-list.component.ts
@@ -1,4 +1,4 @@
-import { ArtifactType } from './../../enums/artifact-type.enum';
+import { ArtifactType } from '@/enums/artifact-type.enum';
 import { ArtifactSummary } from '@/components/artifact-card/artifact-summary.model';
 import {
   FilterSortConfiguration,
@@ -44,7 +44,7 @@ export class ArtifactListComponent implements OnInit {
   }
 
   get placeholderText() {
-    return 'Find an artifact by name…';
+    return 'Find an artifact by set or name…';
   }
 
   hasData() {
@@ -66,7 +66,7 @@ export class ArtifactListComponent implements OnInit {
     }
 
     filteredResults = filteredResults.filter(item =>
-      item.hasTextInName(config.filterText)
+      item.hasTextInSetOrName(config.filterText)
     );
 
     if (sort) {

--- a/src/app/components/character-list/character-list.component.html
+++ b/src/app/components/character-list/character-list.component.html
@@ -1,40 +1,52 @@
-<div class="list-page-header">
-  <h1>Characters</h1>
-</div>
+<h1 class="list-page-header">Characters</h1>
 
 <moe-loading-image *ngIf="!listItems; else elseBlock"></moe-loading-image>
 
 <ng-template #elseBlock>
   <div class="character-page-content">
     <div class="character-list-controls">
-      <a id="group-type-button"
+      <a
+        id="group-type-button"
         class="button-1 background-blue hover-background-gray"
-        (click)="groupButtonClick()">
+        (click)="groupButtonClick()"
+      >
         <span class="group-type-button-label">Group By</span>
         <i class="fas fa-chevron-right"></i>
         <span class="group-type-selected">{{ groupType }}</span>
       </a>
     </div>
 
-      <div class="character-group-section" *ngFor="let listItem of listItems | keyvalue">
-        <div class="character-group-section-header" [ngClass]="
-                    groupType === 'tier'
-                      ? 'background-tier-' + listItem.key
-                      : 'level1-background'
-                  ">
-          <img *ngIf="listItem.value.mainImage" src="{{ listItem.value.mainImage }}" [ngStyle]="{
-                      'margin-left': groupType === 'tier' ? '0em' : '2em',
-                      'margin-right': groupType === 'tier' ? '0em' : '2em'
-                    }" />
-          <div *ngIf="listItem.value.mainLabel">
-            {{ listItem.value.mainLabel }}
-          </div>
-        </div>
-        <div class="character-items-list">
-          <moe-character-card *ngFor="let characterResponse of listItem.value.characters"
-            [character]="characterResponse.toCharacterCardModel()">
-          </moe-character-card>
+    <div
+      class="character-group-section"
+      *ngFor="let listItem of listItems | keyvalue"
+    >
+      <div
+        class="character-group-section-header"
+        [ngClass]="
+          groupType === 'tier'
+            ? 'background-tier-' + listItem.key
+            : 'level1-background'
+        "
+      >
+        <img
+          *ngIf="listItem.value.mainImage"
+          src="{{ listItem.value.mainImage }}"
+          [ngStyle]="{
+            'margin-left': groupType === 'tier' ? '0em' : '2em',
+            'margin-right': groupType === 'tier' ? '0em' : '2em'
+          }"
+        />
+        <div *ngIf="listItem.value.mainLabel">
+          {{ listItem.value.mainLabel }}
         </div>
       </div>
+      <div class="character-items-list">
+        <moe-character-card
+          *ngFor="let characterResponse of listItem.value.characters"
+          [character]="characterResponse.toCharacterCardModel()"
+        >
+        </moe-character-card>
+      </div>
+    </div>
   </div>
 </ng-template>

--- a/src/app/components/filter-sort/filter-sort.component.html
+++ b/src/app/components/filter-sort/filter-sort.component.html
@@ -1,20 +1,26 @@
-<input #moeSearch
-       type="search"
-       class="moe-search-input"
-       [placeholder]="getPlaceholderText()"
-       (keyup)="onSearchInput(moeSearch.value)" />
+<input
+  #moeSearch
+  type="search"
+  class="moe-search-input"
+  [placeholder]="getPlaceholderText()"
+  (input)="onSearchInput(moeSearch.value)"
+/>
 
 <div class="moe-filtersort-bar">
-  <div *ngIf="hasFilterOptions"
-       class="moe-filter-toggle"
-       (click)="toggleFilterMenu()">
+  <div
+    *ngIf="hasFilterOptions"
+    class="moe-filter-toggle"
+    (click)="toggleFilterMenu()"
+  >
     <div class="moe-current-filter-label">Filter By</div>
     <div class="moe-current-filter-option">{{ currentFilter.label }}</div>
   </div>
 
-  <div *ngIf="hasSortOptions"
-       class="moe-sort-toggle"
-       (click)="toggleSortMenu()">
+  <div
+    *ngIf="hasSortOptions"
+    class="moe-sort-toggle"
+    (click)="toggleSortMenu()"
+  >
     <div class="moe-current-sort-label">Sort By</div>
     <div class="moe-current-sort-option">{{ currentSort.label }}</div>
   </div>
@@ -22,20 +28,24 @@
 
 <div class="moe-filtersort-options">
   <div *ngIf="shouldShowFilterOptions()" class="moe-filter-options">
-    <div *ngFor="let option of filterOptions"
-        class="moe-filter-option"
-        [ngClass]="{ selected: option === currentFilter }"
-        (click)="selectFilter(option)">
-        {{ option.label }}
+    <div
+      *ngFor="let option of filterOptions"
+      class="moe-filter-option"
+      [ngClass]="{ selected: option === currentFilter }"
+      (click)="selectFilter(option)"
+    >
+      {{ option.label }}
     </div>
   </div>
 
   <div *ngIf="shouldShowSortOptions()" class="moe-sort-options">
-    <div *ngFor="let option of sortOptions"
-        class="moe-sort-option"
-        [ngClass]="{ selected: option === currentSort }"
-        (click)="selectSort(option)">
-        {{ option.label }}
+    <div
+      *ngFor="let option of sortOptions"
+      class="moe-sort-option"
+      [ngClass]="{ selected: option === currentSort }"
+      (click)="selectSort(option)"
+    >
+      {{ option.label }}
     </div>
   </div>
 </div>

--- a/src/app/components/filter-sort/filter-sort.component.scss
+++ b/src/app/components/filter-sort/filter-sort.component.scss
@@ -1,4 +1,4 @@
-@import "global";
+@import 'global';
 
 :host {
   display: block;
@@ -14,6 +14,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  min-height: 0.75rem;
   position: relative;
 
   .moe-filter-toggle,

--- a/src/app/components/filter-sort/filter-sort.component.spec.ts
+++ b/src/app/components/filter-sort/filter-sort.component.spec.ts
@@ -68,7 +68,7 @@ describe('FilterSortComponent', () => {
         const searchElement =
           fixture.nativeElement.querySelector('.moe-search-input');
         searchElement.value = 'test';
-        searchElement.dispatchEvent(new Event('keyup'));
+        searchElement.dispatchEvent(new Event('input'));
 
         expect(component.filterSortEvent.emit).toHaveBeenCalledWith({
           filterText: 'test',

--- a/src/app/components/weapon-list/weapon-list.component.html
+++ b/src/app/components/weapon-list/weapon-list.component.html
@@ -1,22 +1,21 @@
-<div class="list-page-header">
-  <h1>Weapons</h1>
-</div>
+<h1 class="list-page-header">Weapons</h1>
 
 <moe-loading-image *ngIf="!hasData(); else elseBlock"></moe-loading-image>
 
 <ng-template #elseBlock>
   <div class="weapon-search-container">
-    <moe-filter-sort [placeholderText]="placeholderText"
-                     [filterOptions]="filterOptions"
-                     [sortOptions]="sortOptions"
-                     (filterSortEvent)="updateConfiguration($event)"></moe-filter-sort>
+    <moe-filter-sort
+      [placeholderText]="placeholderText"
+      [filterOptions]="filterOptions"
+      [sortOptions]="sortOptions"
+      (filterSortEvent)="updateConfiguration($event)"
+    ></moe-filter-sort>
   </div>
 
   <div class="weapon-search-results">
     <div class="weapon-results-message">{{ resultsMessage }}</div>
     <div class="weapon-results-grid">
-      <moe-weapon-card *ngFor="let weapon of results"
-                       [weapon]="weapon">
+      <moe-weapon-card *ngFor="let weapon of results" [weapon]="weapon">
       </moe-weapon-card>
     </div>
   </div>

--- a/src/app/components/weapon-list/weapon-list.component.scss
+++ b/src/app/components/weapon-list/weapon-list.component.scss
@@ -1,4 +1,4 @@
-@import "global";
+@import 'global';
 
 :host {
   @include list-page-host;

--- a/src/app/models/artifact.model.ts
+++ b/src/app/models/artifact.model.ts
@@ -25,6 +25,8 @@ export class Artifact {
   toArtifactSummary() {
     return new ArtifactSummary.Builder(this.Id)
       .setName(this.Name)
+      .setSetTitle(this.ArtifactSet.Name)
+      .setType(this.ArtifactType)
       .setRarity(this.Rarity)
       .setImageUrl(this.Image)
       .build();

--- a/src/app/models/artifact.model.ts
+++ b/src/app/models/artifact.model.ts
@@ -1,3 +1,4 @@
+import { ArtifactSummary } from './../components/artifact-card/artifact-summary.model';
 import { ArtifactType } from '@/enums/artifact-type.enum';
 import { Rarity } from '@/enums/rarity.enum';
 import { ArtifactSet } from './artifact-set.model';
@@ -19,5 +20,13 @@ export class Artifact {
     this.Description = artifactJson.description;
     this.ArtifactType = artifactJson.type;
     this.ArtifactSet = new ArtifactSet(artifactJson.artifactSet);
+  }
+
+  toArtifactSummary() {
+    return new ArtifactSummary.Builder(this.Id)
+      .setName(this.Name)
+      .setRarity(this.Rarity)
+      .setImageUrl(this.Image)
+      .build();
   }
 }

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,5 +1,5 @@
-@import "constants";
-@import "html";
+@import 'constants';
+@import 'html';
 
 /* App component backgrounds. */
 
@@ -21,18 +21,15 @@
 }
 
 .list-page-header {
-  align-items: center;
   background-image: url(https://media.impact.moe/img/banners/banner-1.webp);
   background-size: cover;
   background-position: center;
   cursor: default;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  height: 8rem;
+  padding: 2rem 1rem;
+  text-align: center;
 
   @media (min-width: $tablet-min-width) {
-    height: 12rem;
+    padding: 4rem 1rem;
   }
 }
 


### PR DESCRIPTION
Changes include:

1. Card component for individual artifact display
2. Model for artifact object to centralize sorts / comparison logic
3. Updating artifacts list page to use the same grid styling as character / weapon pages
4. Filter sort logic for the artifacts list page

Notably some logic is starting to be repeated and may call for something like a filter-sort controller to centralize things like performance optimizations. However it's probably reasonable to follow up with that later cuz there might be some last changes w/ the character page, plus 0 -> 1 is already a big gain here.

Check out demo gif below:
![artifact-filter-sort-v1](https://user-images.githubusercontent.com/52547470/121765508-1d7b7200-cb00-11eb-8422-80710e429468.gif)
